### PR TITLE
Feat: BaseTimeEntity 공통 엔티티 도입

### DIFF
--- a/src/main/java/team/unibusk/backend/global/domain/BaseTimeEntity.java
+++ b/src/main/java/team/unibusk/backend/global/domain/BaseTimeEntity.java
@@ -1,0 +1,26 @@
+package team.unibusk.backend.global.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+    @CreationTimestamp
+    @Column(nullable = false, updatable = false)
+    protected LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(nullable = false)
+    protected LocalDateTime updatedAt;
+
+}


### PR DESCRIPTION
## 관련 이슈
- #3 

## Summary

- 공통 엔티티에서 생성/수정 시간을 자동으로 관리하기 위한 BaseTimeEntity를 도입했습니다.
- JPA Auditing 및 Hibernate Timestamp 기능을 활용하여 모든 엔티티에서 중복 코드 없이 createdAt, updatedAt 필드를 일관되게 관리할 수 있도록 구성했습니다.

## Tasks

- 공통 시간 관리 추상 클래스 BaseTimeEntity 추가
- @MappedSuperclass를 통해 엔티티 상속 구조 설계
- 생성 시각 자동 주입을 위한 @CreationTimestamp 적용
- 수정 시각 자동 갱신을 위한 @UpdateTimestamp 적용
- JPA Auditing 적용을 위한 AuditingEntityListener 설정