### PR TITLE
Feat: 로그아웃 기능 구현

### DIFF
--- a/src/main/java/team/unibusk/backend/global/auth/domain/refreshtoken/RefreshTokenRepository.java
+++ b/src/main/java/team/unibusk/backend/global/auth/domain/refreshtoken/RefreshTokenRepository.java
@@ -10,4 +10,6 @@ public interface RefreshTokenRepository {
 
     Optional<RefreshToken> findFirstByMemberIdOrderByIdDesc(Long id);
 
+    void deleteByMemberId(Long memberId);
+
 }

--- a/src/main/java/team/unibusk/backend/global/auth/infrastructure/RefreshTokenJpaRepository.java
+++ b/src/main/java/team/unibusk/backend/global/auth/infrastructure/RefreshTokenJpaRepository.java
@@ -11,4 +11,6 @@ public interface RefreshTokenJpaRepository extends JpaRepository<RefreshToken, L
 
     Optional<RefreshToken> findFirstByMemberIdOrderByIdDesc(Long id);
 
+    void deleteByMemberId(Long memberId);
+
 }

--- a/src/main/java/team/unibusk/backend/global/auth/infrastructure/RefreshTokenRepositoryImpl.java
+++ b/src/main/java/team/unibusk/backend/global/auth/infrastructure/RefreshTokenRepositoryImpl.java
@@ -28,4 +28,9 @@ public class RefreshTokenRepositoryImpl implements RefreshTokenRepository {
         return refreshTokenJpaRepository.findFirstByMemberIdOrderByIdDesc(id);
     }
 
+    @Override
+    public void deleteByMemberId(Long memberId) {
+        refreshTokenJpaRepository.deleteByMemberId(memberId);
+    }
+
 }

--- a/src/main/java/team/unibusk/backend/global/auth/presentation/AuthController.java
+++ b/src/main/java/team/unibusk/backend/global/auth/presentation/AuthController.java
@@ -1,18 +1,34 @@
 package team.unibusk.backend.global.auth.presentation;
 
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import team.unibusk.backend.global.annotation.MemberId;
+import team.unibusk.backend.global.auth.application.auth.AuthService;
 
 @RequiredArgsConstructor
 @RequestMapping("/auths")
 @Controller
 public class AuthController {
 
+    private final AuthService authService;
+
     @GetMapping("/login")
     public String login() {
         return "redirect:/oauth2/authorization/kakao";
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout(
+            @MemberId Long memberId,
+            HttpServletResponse response
+    ) {
+        authService.logout(memberId, response);
+        return ResponseEntity.ok().build();
     }
 
 }


### PR DESCRIPTION
## 관련 이슈
- #16 

## Summary

사용자 로그아웃 기능을 구현했습니다.
클라이언트 측 쿠키에 저장된 액세스 토큰과 리프레시 토큰을 무효화하고,
서버 측 Redis(또는 DB)에 저장된 리프레시 토큰을 삭제하여 세션을 완전히 종료합니다.

## Tasks

- 로그아웃 서비스 로직 추가
- 액세스 토큰 및 리프레시 토큰 쿠키 무효화 기능 구현
- DB/Redis에 저장된 리프레시 토큰 삭제 기능 추가
- 로그아웃 요청을 처리하는 API 컨트롤러 추가 (POST /auths/logout)