### PR TITLE
Refactor: OAuth2 State Redirect Flow 적용

### DIFF
--- a/src/main/java/team/unibusk/backend/global/auth/presentation/security/RedirectUrlFilter.java
+++ b/src/main/java/team/unibusk/backend/global/auth/presentation/security/RedirectUrlFilter.java
@@ -23,15 +23,17 @@ public class RedirectUrlFilter extends OncePerRequestFilter {
 
     private final TokenInjector tokenInjector;
 
-    public static final String REDIRECT_URL_QUERY_PARAM = "redirectUrl";
-    public static final String REDIRECT_URL_COOKIE_NAME = "redirect_url";
+    public static final String STATE_PARAM = "state";
+    public static final String STATE_COOKIE_NAME = "oauth_state";
 
     private static final List<String> REDIRECT_URL_INJECTION_PATTERNS = List.of(
             "/oauth2/authorization/**"
     );
 
     private static final List<String> ALLOWED_REDIRECT_HOSTS = List.of(
-            "localhost"
+            "localhost",
+            "unibusk.site",
+            "www.unibusk.site"
     );
 
     private final AntPathMatcher pathMatcher = new AntPathMatcher();
@@ -44,12 +46,12 @@ public class RedirectUrlFilter extends OncePerRequestFilter {
     ) throws ServletException, IOException {
 
         if (isRedirectRequest(request)) {
-            tokenInjector.invalidateCookie(REDIRECT_URL_COOKIE_NAME, response);
+            tokenInjector.invalidateCookie(STATE_COOKIE_NAME, response);
 
-            String redirectUri = request.getParameter(REDIRECT_URL_QUERY_PARAM);
-            if (StringUtils.hasText(redirectUri) && isValidRedirectUrl(redirectUri)) {
-                String encodedUri = URLEncoder.encode(redirectUri, StandardCharsets.UTF_8);
-                tokenInjector.addCookie(REDIRECT_URL_COOKIE_NAME, encodedUri, 3600, response);
+            String state = request.getParameter(STATE_PARAM);
+            if (StringUtils.hasText(state) && isValidRedirectUrl(state)) {
+                String encodedState = URLEncoder.encode(state, StandardCharsets.UTF_8);
+                tokenInjector.addCookie(STATE_COOKIE_NAME, encodedState, 3600, response);
             }
         }
 

--- a/src/main/java/team/unibusk/backend/global/config/SecurityConfig.java
+++ b/src/main/java/team/unibusk/backend/global/config/SecurityConfig.java
@@ -70,6 +70,7 @@ public class SecurityConfig {
         httpSecurity.cors(cors -> cors.configurationSource(request -> {
             var corsConfiguration = new CorsConfiguration();
             corsConfiguration.setAllowedOrigins(List.of(
+                    "http://localhost:3000",
                     "http://localhost:8080",
                     "https://unibusk.site",
                     "https://www.unibusk.site"


### PR DESCRIPTION
## 관련 이슈
- #27 

## Summary

카카오 OAuth2 로그인 플로우 개선 및 FE → BE → FE Redirect 경로 정상화 작업을 진행했습니다.
기존에는 로그인 성공 후 백엔드에서 고정된 URL로 리다이렉트되었으나,
state 값을 활용해 로그인 요청 시 전달된 프론트엔드 콜백 URL로 안전하게 이동하도록 수정했습니다.

## Tasks

- OAuth2 요청 시 전달된 state를 쿠키에 저장하도록 RedirectUrlFilter 추가
- 로그인 성공 시 state 쿠키 값을 기반으로 FE 콜백 URL로 리다이렉트 처리
- 비정상 리다이렉트 요청 시 fallback URL 사용하도록 예외 처리 적용
- Auth2LoginSuccessHandler 리팩토링 및 Cookie Key 변경(redirect_url → oauth_state)
- 코드 정리 및 불필요한 로직 제거


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * unibusk.site 도메인에 대한 지원 추가

* **개선 사항**
  * 인증 및 리다이렉트 보안 메커니즘 강화
  * 교차 출처 요청 구성 최적화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->