### PR TITLE
fix: restrict oauth redirect to allowed hosts

### DIFF
--- a/src/main/java/team/unibusk/backend/global/auth/presentation/security/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/team/unibusk/backend/global/auth/presentation/security/handler/OAuth2LoginSuccessHandler.java
@@ -17,9 +17,11 @@ import team.unibusk.backend.global.jwt.config.SecurityProperties;
 import team.unibusk.backend.global.jwt.injector.TokenInjector;
 
 import java.io.IOException;
+import java.net.URI;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Objects;
 
 import static team.unibusk.backend.global.auth.presentation.exception.AuthExceptionCode.ALREADY_REGISTERED_MEMBER;
@@ -33,6 +35,12 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
     private final AuthService authService;
     private final TokenInjector tokenInjector;
     private final SecurityProperties securityProperties;
+
+    private static final List<String> ALLOWED_REDIRECT_HOSTS = List.of(
+            "localhost",
+            "unibusk.site",
+            "www.unibusk.site"
+    );
 
     @Override
     public void onAuthenticationSuccess(
@@ -101,7 +109,18 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
     }
 
     private boolean isValidRedirectUrl(String url) {
-        return url.startsWith("/") || url.startsWith(securityProperties.oAuthUrl().redirectUrl());
+        try {
+            URI uri = URI.create(url);
+
+            if (uri.getHost() == null) {
+                return true;
+            }
+
+            return ALLOWED_REDIRECT_HOSTS.contains(uri.getHost());
+        } catch (Exception e) {
+            log.warn("[OAuth2Success] invalid redirect url={}", url);
+            return false;
+        }
     }
 
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **보안 개선**
  * OAuth2 로그인 리다이렉트 URL 검증 강화
  * 허용 목록 기반 호스트 검증으로 보안성 향상
  * 지원 도메인: localhost, unibusk.site, www.unibusk.site
  * 잘못된 리다이렉트 URL에 대한 거부 및 로깅 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->