### PR TITLE
Infra: Docker 컨테이너 시간대를 한국(KST)으로 설정

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM eclipse-temurin:17-jdk
 
+ENV TZ=Asia/Seoul
+
 ARG JAR_FILE=build/libs/*.jar
 
 COPY ${JAR_FILE} app.jar


### PR DESCRIPTION
## 관련 이슈
- 관련 이슈 태그해주세요.

## Summary

컨테이너 시간대를 한국으로 설정했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 컨테이너의 기본 타임존을 Asia/Seoul로 설정했습니다. 애플리케이션의 모든 시간 관련 작업과 로그 출력이 서울 시간대(UTC+9)를 기준으로 작동합니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->