### PR TITLE
Chore: MemberNameUpdateResponse 응답 값 변경

### DIFF
--- a/src/main/java/team/unibusk/backend/domain/member/application/MemberService.java
+++ b/src/main/java/team/unibusk/backend/domain/member/application/MemberService.java
@@ -23,6 +23,8 @@ public class MemberService {
 
         return MemberNameUpdateResponse.builder()
                 .memberId(member.getId())
+                .email(member.getEmail())
+                .name(member.getName())
                 .build();
     }
 

--- a/src/main/java/team/unibusk/backend/domain/member/application/dto/response/MemberNameUpdateResponse.java
+++ b/src/main/java/team/unibusk/backend/domain/member/application/dto/response/MemberNameUpdateResponse.java
@@ -7,7 +7,13 @@ import lombok.Builder;
 public record MemberNameUpdateResponse(
 
         @Schema(description = "이름이 수정된 회원의 ID", example = "1")
-        Long memberId
+        Long memberId,
+
+        @Schema(description = "이름이 수정된 회원 이메일", example = "hong@unibusk.com")
+        String email,
+
+        @Schema(description = "이름이 수정된 회원 이름", example = "홍길동동")
+        String name
 
 ) {
 }

--- a/src/main/java/team/unibusk/backend/domain/member/presentation/request/MemberNameUpdateRequest.java
+++ b/src/main/java/team/unibusk/backend/domain/member/presentation/request/MemberNameUpdateRequest.java
@@ -9,7 +9,7 @@ import team.unibusk.backend.domain.member.application.dto.request.MemberNameUpda
 @Builder
 public record MemberNameUpdateRequest(
 
-        @Schema(description = "새로운 회원 이름", example = "홍길동", maxLength = 15)
+        @Schema(description = "새로운 회원 이름", example = "홍길동동", maxLength = 15)
         @NotBlank(message = "이름을 입력해 주세요.")
         @Size(max = 15, message = "이름은 최대 15글자까지 작성 가능합니다.")
         String name


### PR DESCRIPTION
## 관련 이슈
- #49 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
* 회원 이름 변경 응답에 회원 ID, 이메일, 이름 정보가 모두 포함되도록 개선되었습니다.

## 문서
* API 문서의 예제값이 업데이트되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->