### PR TITLE
Fix: 공연 등록 API multipart 요청 415 오류 수정

### DIFF
--- a/src/main/java/team/unibusk/backend/domain/performance/presentation/PerformanceDocsController.java
+++ b/src/main/java/team/unibusk/backend/domain/performance/presentation/PerformanceDocsController.java
@@ -3,6 +3,7 @@ package team.unibusk.backend.domain.performance.presentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Encoding;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -17,6 +18,7 @@ import org.springframework.web.multipart.MultipartFile;
 import team.unibusk.backend.domain.performance.application.dto.response.PerformanceRegisterResponse;
 import team.unibusk.backend.domain.performance.presentation.request.PerformanceRegisterRequest;
 import team.unibusk.backend.global.annotation.MemberId;
+import team.unibusk.backend.global.annotation.SwaggerBody;
 import team.unibusk.backend.global.exception.ExceptionResponse;
 
 import java.util.List;
@@ -38,12 +40,14 @@ public interface PerformanceDocsController{
             @ApiResponse(responseCode = "500", description = "이미지 업로드 실패 등 서버 오류",
                     content = @Content(schema = @Schema(implementation = ExceptionResponse.class)))
     })
-
-    @PostMapping(value = "/register", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @SwaggerBody(content = @Content(
+            encoding = @Encoding(name = "request", contentType = MediaType.APPLICATION_JSON_VALUE)))
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     ResponseEntity<PerformanceRegisterResponse> registerPerformance(
             @RequestPart("request") @Valid PerformanceRegisterRequest request,
             @Parameter(description = "공연 관련 이미지 리스트 (다중 파일 업로드 가능)")
             @RequestPart(value = "images", required = false) List<MultipartFile> images,
             @MemberId Long memberId
     );
+
 }

--- a/src/main/java/team/unibusk/backend/global/annotation/SwaggerBody.java
+++ b/src/main/java/team/unibusk/backend/global/annotation/SwaggerBody.java
@@ -1,0 +1,34 @@
+package team.unibusk.backend.global.annotation;
+
+import io.swagger.v3.oas.annotations.extensions.Extension;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import org.springframework.core.annotation.AliasFor;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.PARAMETER, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@RequestBody
+@Inherited
+public @interface SwaggerBody {
+
+    @AliasFor(annotation = RequestBody.class)
+    String description() default "";
+
+    @AliasFor(annotation = RequestBody.class)
+    Content[] content() default {};
+
+    @AliasFor(annotation = RequestBody.class)
+    boolean required() default false;
+
+    @AliasFor(annotation = RequestBody.class)
+    Extension[] extensions() default {};
+
+    @AliasFor(annotation = RequestBody.class)
+    String ref() default "";
+
+    @AliasFor(annotation = RequestBody.class)
+    boolean useParameterTypeSchema() default false;
+
+}


### PR DESCRIPTION
## 관련 이슈
- #59 

## Summary

Swagger 문서에서 multipart/form-data 요청 바디가 올바르게 정의되지 않아 발생하던
공연 등록 API의 415(Unsupported Media Type) 오류를 수정했습니다.

커스텀 어노테이션(@SwaggerBody)을 통해
Swagger 요청 바디 정의를 @RequestPart 기반 멀티파트 요청 구조에 맞게 정렬했습니다.

## Tasks

- Swagger용 커스텀 어노테이션(@SwaggerBody) 정의 및 적용
- multipart/form-data 요청에 맞게 Swagger RequestBody 설정 수정
- 공연 등록 API 호출 시 발생하던 415 오류 해결


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * API 문서화를 위한 새로운 어노테이션 추가
  * 요청 본문에 대한 상세한 Swagger/OpenAPI 메타데이터 지원 추가

* **Chores**
  * 성능 등록 엔드포인트 경로 구조 정규화
  * API 문서화 메타데이터 개선

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->