### PR TITLE
Refactor: 첫 로그인 시 랜덤 닉네임에 회원 ID를 더해 중복 방지

### DIFF
--- a/src/main/java/team/unibusk/backend/global/auth/application/auth/AuthService.java
+++ b/src/main/java/team/unibusk/backend/global/auth/application/auth/AuthService.java
@@ -73,8 +73,11 @@ public class AuthService {
 
     private Member saveNewMember(AuthAttributes attributes) {
         Member member = Member.from(attributes);
-        member.generateName(randomNameGenerator.generate());
-        return memberRepository.save(member);
+        memberRepository.save(member);
+        member.generateName(
+                randomNameGenerator.generate() + member.getId()
+        );
+        return member;
     }
 
 }


### PR DESCRIPTION
## 관련 이슈
- 관련 이슈 태그해주세요.

## Summary

신규 회원 첫 로그인 시 랜덤 닉네임 생성 방식에 회원 ID를 추가하여  
닉네임 중복 가능성을 줄이도록 개선했습니다.

## Tasks

- 신규 회원 저장 후 memberId를 포함한 랜덤 닉네임 생성 로직 적용
- 닉네임 중복 방지를 위한 Member 생성 흐름 리팩터링
