### PR TITLE
Feat: 버스킹 장소 이름/주소 키워드 검색 리스트 반환

### DIFF
--- a/src/main/java/team/unibusk/backend/domain/performanceLocation/application/PerformanceLocationService.java
+++ b/src/main/java/team/unibusk/backend/domain/performanceLocation/application/PerformanceLocationService.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import team.unibusk.backend.domain.performanceLocation.application.dto.response.PerformanceLocationListResponse;
 import team.unibusk.backend.domain.performanceLocation.application.dto.response.PerformanceLocationMapListResponse;
+import team.unibusk.backend.domain.performanceLocation.application.dto.response.PerformanceLocationSearchListResponse;
 import team.unibusk.backend.domain.performanceLocation.domain.MapBounds;
 import team.unibusk.backend.domain.performanceLocation.domain.PerformanceLocation;
 import team.unibusk.backend.domain.performanceLocation.domain.PerformanceLocationRepository;
@@ -41,6 +42,15 @@ public class PerformanceLocationService {
         List<PerformanceLocation> performanceLocations = performanceLocationRepository.findInMapBounds(north, south, east, west);
 
         return PerformanceLocationMapListResponse.from(performanceLocations);
+    }
+
+    @Transactional(readOnly = true)
+    public PerformanceLocationSearchListResponse searchByNameOrAddress(String keyword) {
+        validateKeyword(keyword);
+
+        List<PerformanceLocation> locations = performanceLocationRepository.searchByNameOrAddress(keyword);
+
+        return PerformanceLocationSearchListResponse.from(locations);
     }
 
     //keyword에 대한 검증. (길이, null 검사)

--- a/src/main/java/team/unibusk/backend/domain/performanceLocation/application/dto/response/PerformanceLocationSearchListResponse.java
+++ b/src/main/java/team/unibusk/backend/domain/performanceLocation/application/dto/response/PerformanceLocationSearchListResponse.java
@@ -1,0 +1,27 @@
+package team.unibusk.backend.domain.performanceLocation.application.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import team.unibusk.backend.domain.performanceLocation.domain.PerformanceLocation;
+
+import java.util.List;
+
+@Schema(name = "PerformanceLocationSearchListResponse", description = "검색된 공연 장소 리스트 응답 DTO")
+@Builder
+public record PerformanceLocationSearchListResponse(
+
+        @Schema(description = "검색된 공연 장소 리스트")
+        List<PerformanceLocationSearchResponse> performanceLocationSearchResponses
+
+) {
+
+    public static PerformanceLocationSearchListResponse from(List<PerformanceLocation> performanceLocations) {
+        return PerformanceLocationSearchListResponse.builder()
+                .performanceLocationSearchResponses(
+                        performanceLocations.stream().map(PerformanceLocationSearchResponse::from)
+                                .toList()
+                )
+                .build();
+    }
+
+}

--- a/src/main/java/team/unibusk/backend/domain/performanceLocation/application/dto/response/PerformanceLocationSearchResponse.java
+++ b/src/main/java/team/unibusk/backend/domain/performanceLocation/application/dto/response/PerformanceLocationSearchResponse.java
@@ -1,0 +1,67 @@
+package team.unibusk.backend.domain.performanceLocation.application.dto.response;
+
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import team.unibusk.backend.domain.performanceLocation.domain.PerformanceLocation;
+import team.unibusk.backend.domain.performanceLocation.domain.PerformanceLocationImage;
+
+import java.util.List;
+
+@Builder
+public record PerformanceLocationSearchResponse(
+
+        @Schema(description = "공연 장소 ID", example = "1")
+        Long performanceLocationId,
+
+        @Schema(description = "공연 장소 이름", example = "홍대 버스킹 스팟")
+        String name,
+
+        @Schema(description = "주소", example = "서울특별시 마포구 홍익로")
+        String address,
+
+        @Schema(description = "운영기관", example = "마포구청")
+        String operatorName,
+
+        @Schema(description = "운영기관 번호", example = "3111-1111")
+        String operatorPhoneNumber,
+
+        @Schema(description = "운영 가능 시간", example = "10:00~22:00")
+        String availableHours,
+
+        @Schema(description = "운영기관 신청 URL", example = "https://busking.example.com")
+        String operatorUrl,
+
+        @Schema(description = "위도", example = "37.5563")
+        Double latitude,
+
+        @Schema(description = "경도", example = "126.9238")
+        Double longitude,
+
+        @ArraySchema(
+                schema = @Schema(description = "공연 장소 이미지 URL 리스트", example = "https://cdn.example.com/img1.jpg")
+        )
+        List<String> imageUrls
+
+) {
+
+    public static PerformanceLocationSearchResponse from(PerformanceLocation performanceLocation) {
+        return PerformanceLocationSearchResponse.builder()
+                .performanceLocationId(performanceLocation.getId())
+                .name(performanceLocation.getName())
+                .address(performanceLocation.getAddress())
+                .operatorName(performanceLocation.getOperatorName())
+                .operatorPhoneNumber(performanceLocation.getOperatorPhoneNumber())
+                .availableHours(performanceLocation.getAvailableHours())
+                .operatorUrl(performanceLocation.getOperatorUrl())
+                .latitude(performanceLocation.getLatitude())
+                .longitude(performanceLocation.getLongitude())
+                .imageUrls(
+                        performanceLocation.getImages().stream()
+                                .map(PerformanceLocationImage::getImageUrl)
+                                .toList()
+                )
+                .build();
+    }
+
+}

--- a/src/main/java/team/unibusk/backend/domain/performanceLocation/domain/PerformanceLocationRepository.java
+++ b/src/main/java/team/unibusk/backend/domain/performanceLocation/domain/PerformanceLocationRepository.java
@@ -23,4 +23,6 @@ public interface PerformanceLocationRepository {
 
     List<PerformanceLocation> findInMapBounds(Double north, Double south, Double east, Double west);
 
+    List<PerformanceLocation> searchByNameOrAddress(String keyword);
+
 }

--- a/src/main/java/team/unibusk/backend/domain/performanceLocation/infrastructure/PerformanceLocationQueryDslRepository.java
+++ b/src/main/java/team/unibusk/backend/domain/performanceLocation/infrastructure/PerformanceLocationQueryDslRepository.java
@@ -24,4 +24,17 @@ public class PerformanceLocationQueryDslRepository {
                 .fetch();
     }
 
+    public List<PerformanceLocation> searchByNameOrAddress(String keyword) {
+        QPerformanceLocation location = QPerformanceLocation.performanceLocation;
+
+        return queryFactory
+                .selectFrom(location)
+                .where(
+                        location.name.containsIgnoreCase(keyword)
+                                .or(location.address.containsIgnoreCase(keyword))
+                )
+                .fetch();
+    }
+
+
 }

--- a/src/main/java/team/unibusk/backend/domain/performanceLocation/infrastructure/PerformanceLocationRepositoryImpl.java
+++ b/src/main/java/team/unibusk/backend/domain/performanceLocation/infrastructure/PerformanceLocationRepositoryImpl.java
@@ -54,4 +54,9 @@ public class PerformanceLocationRepositoryImpl implements PerformanceLocationRep
         return performanceLocationQueryDslRepository.findInMapBounds(north, south, east, west);
     }
 
+    @Override
+    public List<PerformanceLocation> searchByNameOrAddress(String keyword) {
+        return performanceLocationQueryDslRepository.searchByNameOrAddress(keyword);
+    }
+
 }

--- a/src/main/java/team/unibusk/backend/domain/performanceLocation/presentation/PerformanceLocationController.java
+++ b/src/main/java/team/unibusk/backend/domain/performanceLocation/presentation/PerformanceLocationController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.*;
 import team.unibusk.backend.domain.performanceLocation.application.PerformanceLocationService;
 import team.unibusk.backend.domain.performanceLocation.application.dto.response.PerformanceLocationListResponse;
 import team.unibusk.backend.domain.performanceLocation.application.dto.response.PerformanceLocationMapListResponse;
+import team.unibusk.backend.domain.performanceLocation.application.dto.response.PerformanceLocationSearchListResponse;
 import team.unibusk.backend.domain.performanceLocation.presentation.exception.EmptyKeywordException;
 import team.unibusk.backend.domain.performanceLocation.presentation.exception.InvalidKeywordLengthException;
 
@@ -40,6 +41,16 @@ public class PerformanceLocationController implements PerformanceLocationDocsCon
     ) {
         PerformanceLocationMapListResponse response =
                 performanceLocationService.findInMapBoundsResponse(north, south, east, west);
+        return ResponseEntity.status(200).body(response);
+    }
+
+    @GetMapping("/search/list")
+    public ResponseEntity<PerformanceLocationSearchListResponse> searchList(
+            @RequestParam("keyword") String keyword
+    ) {
+        PerformanceLocationSearchListResponse response =
+                performanceLocationService.searchByNameOrAddress(keyword);
+
         return ResponseEntity.status(200).body(response);
     }
 

--- a/src/main/java/team/unibusk/backend/domain/performanceLocation/presentation/PerformanceLocationDocsController.java
+++ b/src/main/java/team/unibusk/backend/domain/performanceLocation/presentation/PerformanceLocationDocsController.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestParam;
 import team.unibusk.backend.domain.performanceLocation.application.dto.response.PerformanceLocationMapListResponse;
+import team.unibusk.backend.domain.performanceLocation.application.dto.response.PerformanceLocationSearchListResponse;
 import team.unibusk.backend.global.exception.ExceptionResponse;
 
 @Tag(name = "Performance Location", description = "버스킹 장소 관련 API")
@@ -38,4 +39,27 @@ public interface PerformanceLocationDocsController {
             @Parameter(description = "동쪽 경도", required = true) @RequestParam("east") Double east,
             @Parameter(description = "서쪽 경도", required = true) @RequestParam("west") Double west
     );
+
+    @Operation(
+            summary = "버스킹 장소 검색 (리스트)",
+            description = "공연 장소의 이름(name) 또는 주소(address)에 keyword가 포함된 모든 장소를 리스트로 조회합니다.",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "조회 성공",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(implementation = PerformanceLocationSearchListResponse.class)
+                            )
+                    ),
+                    @ApiResponse(responseCode = "400", description = "잘못된 요청",
+                            content = @Content(schema = @Schema(implementation = ExceptionResponse.class))),
+                    @ApiResponse(responseCode = "500", description = "서버 에러",
+                            content = @Content(schema = @Schema(implementation = ExceptionResponse.class)))
+            }
+    )
+    ResponseEntity<PerformanceLocationSearchListResponse> searchList(
+            @Parameter(description = "검색 키워드", required = true) @RequestParam("keyword") String keyword
+    );
+
 }


### PR DESCRIPTION
## 관련 이슈
- #79 

## Summary

공연 장소(PerformanceLocation)의 이름(name) 또는 주소(address)에 포함된 키워드(keyword)로 검색하는 기능을 추가했습니다.
페이징 없이 검색 결과를 리스트 형태로 반환하며, 결과가 없을 경우 빈 리스트를 반환하도록 처리했습니다.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 공연장을 이름 또는 주소로 검색할 수 있는 새로운 검색 기능이 추가되었습니다. 
  * 검색 기능은 새로운 API 엔드포인트를 통해 제공되며, 키워드 기반의 빠른 검색을 지원합니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->