### PR TITLE
Refactor: PerformanceLocationDetailResponse에 operatorUrl 추가로 신청 사이트 주소 전달

### DIFF
--- a/src/main/java/team/unibusk/backend/domain/performanceLocation/application/dto/response/PerformanceLocationDetailResponse.java
+++ b/src/main/java/team/unibusk/backend/domain/performanceLocation/application/dto/response/PerformanceLocationDetailResponse.java
@@ -29,6 +29,9 @@ public record PerformanceLocationDetailResponse(
         @Schema(description = "운영 가능 시간", example = "10:00~22:00")
         String availableHours,
 
+        @Schema(description = "신청 사이트 주소", example = "https://example.com")
+        String operatorUrl,
+
         @Schema(description = "위도", example = "37.5563")
         Double latitude,
 
@@ -50,6 +53,7 @@ public record PerformanceLocationDetailResponse(
                 .operatorName(performanceLocation.getOperatorName())
                 .operatorPhoneNumber(performanceLocation.getOperatorPhoneNumber())
                 .availableHours(performanceLocation.getAvailableHours())
+                .operatorUrl(performanceLocation.getOperatorUrl())
                 .latitude(performanceLocation.getLatitude())
                 .longitude(performanceLocation.getLongitude())
                 .imageUrls(


### PR DESCRIPTION
## 관련 이슈
- #91 

## Summary

PerformanceLocationDetailResponse에 operatorUrl 필드값을 추가하여 신청 사이트 주소를 전달합니다.

## Tasks

- PerformanceLocationDetailResponse에 operatorUrl 필드값 추가


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 공연 장소 상세 정보에 운영자 URL이 추가되었습니다. 사용자는 이제 공연 장소 조회 시 운영자의 웹사이트나 관련 정보에 직접 접근할 수 있습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->