### PR TITLE
Chore: 공연 및 사용자 API 접근 권한 정책 수정

### DIFF
--- a/src/main/java/team/unibusk/backend/global/config/SecurityConfig.java
+++ b/src/main/java/team/unibusk/backend/global/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package team.unibusk.backend.global.config;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
@@ -97,7 +98,15 @@ public class SecurityConfig {
         httpSecurity.authorizeHttpRequests(authorize ->
                 authorize.requestMatchers(CorsUtils::isPreFlightRequest).permitAll()
                         .requestMatchers(PERMIT_ALL_PATTERNS).permitAll()
-                        .anyRequest().authenticated()
+
+                        .requestMatchers(HttpMethod.POST, "/performances").authenticated()
+                        .requestMatchers(HttpMethod.PATCH, "/performances/*").authenticated()
+                        .requestMatchers(HttpMethod.DELETE, "/performances/*").authenticated()
+
+                        .requestMatchers("/members/**").authenticated()
+                        .requestMatchers("/auths/logout").authenticated()
+
+                        .anyRequest().permitAll()
         );
     }
 


### PR DESCRIPTION
## 관련 이슈
- #98 

## Summary

Spring Security 설정을 정비하여 인증이 필요한 API와 공개 API를 분리했습니다.

## Tasks

- 공연 조회 등 공개 API는 인증 없이 접근 가능하도록 설정
- 공연 등록/수정/삭제, 내 정보 조회, 로그아웃 등 사용자 컨텍스트가 필요한 API에 authenticated() 적용


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 보안 개선

* **Refactor**
  * 인증 규칙을 세분화하여 적용했습니다. 성능 정보 생성/수정/삭제, 회원 정보 접근, 로그아웃 기능은 이제 인증이 필수입니다. 그 외의 요청은 인증 없이 접근 가능하도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->