### PR TITLE
Feat: 특정 버스킹 장소의 다가오는 공연 커서 기반 조회 기능 구현

### DIFF
--- a/src/main/java/team/unibusk/backend/domain/performance/application/dto/response/PerformanceCursorResponse.java
+++ b/src/main/java/team/unibusk/backend/domain/performance/application/dto/response/PerformanceCursorResponse.java
@@ -1,0 +1,53 @@
+package team.unibusk.backend.domain.performance.application.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import team.unibusk.backend.domain.performance.domain.Performance;
+import team.unibusk.backend.domain.performance.domain.PerformanceImage;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Builder
+public record PerformanceCursorResponse(
+
+        @Schema(description = "공연 ID", example = "101")
+        Long performanceId,
+
+        @Schema(description = "공연 제목", example = "봄의 선율 콘서트")
+        String title,
+
+        @Schema(description = "공연 날짜", example = "2026-03-18")
+        LocalDate performanceDate,
+
+        @Schema(description = "공연 시작 일시", example = "2026-03-18T19:00:00")
+        LocalDateTime startTime,
+
+        @Schema(description = "공연 종료 일시", example = "2026-03-18T21:00:00")
+        LocalDateTime endTime,
+
+        @Schema(
+                description = "공연 이미지 URL 목록",
+                example = "[\"https://unibusk-bucket.s3.ap-northeast-2.amazonaws.com/performance/123e4567.jpg\"]"
+        )
+        List<String> images
+
+) {
+
+    public static PerformanceCursorResponse from(Performance performance) {
+        return PerformanceCursorResponse.builder()
+                .performanceId(performance.getId())
+                .title(performance.getTitle())
+                .performanceDate(performance.getPerformanceDate())
+                .startTime(performance.getStartTime())
+                .endTime(performance.getEndTime())
+                .images(
+                        performance.getImages().stream()
+                                .map(PerformanceImage::getImageUrl)
+                                .toList()
+                )
+                .build();
+    }
+
+}

--- a/src/main/java/team/unibusk/backend/domain/performance/domain/PerformanceRepository.java
+++ b/src/main/java/team/unibusk/backend/domain/performance/domain/PerformanceRepository.java
@@ -31,4 +31,11 @@ public interface PerformanceRepository {
             Pageable pageable
     );
 
+    List<Performance> findUpcomingByPerformanceLocationWithCursor(
+            Long performanceLocationId,
+            LocalDateTime cursorTime,
+            Long cursorId,
+            int size
+    );
+
 }

--- a/src/main/java/team/unibusk/backend/domain/performance/infrastructure/PerformanceRepositoryImpl.java
+++ b/src/main/java/team/unibusk/backend/domain/performance/infrastructure/PerformanceRepositoryImpl.java
@@ -62,4 +62,15 @@ public class PerformanceRepositoryImpl implements PerformanceRepository {
         return performanceQueryDslRepository.searchByCondition(status, keyword, pageable);
     }
 
+    @Override
+    public List<Performance> findUpcomingByPerformanceLocationWithCursor(
+            Long performanceLocationId,
+            LocalDateTime cursorTime,
+            Long cursorId,
+            int size
+    ) {
+        return performanceQueryDslRepository
+                .findUpcomingByPerformanceLocationWithCursor(performanceLocationId, cursorTime, cursorId, size);
+    }
+
 }

--- a/src/main/java/team/unibusk/backend/domain/performance/presentation/PerformanceController.java
+++ b/src/main/java/team/unibusk/backend/domain/performance/presentation/PerformanceController.java
@@ -15,8 +15,10 @@ import team.unibusk.backend.domain.performance.domain.PerformanceStatus;
 import team.unibusk.backend.domain.performance.presentation.request.PerformanceRegisterRequest;
 import team.unibusk.backend.domain.performance.presentation.request.PerformanceUpdateRequest;
 import team.unibusk.backend.global.annotation.MemberId;
+import team.unibusk.backend.global.response.CursorResponse;
 import team.unibusk.backend.global.response.PageResponse;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @RestController
@@ -141,4 +143,23 @@ public class PerformanceController implements PerformanceDocsController{
 
         return ResponseEntity.status(200).body(response);
     }
+
+    @GetMapping("/locations/{performanceLocationId}/upcoming")
+    public ResponseEntity<CursorResponse<PerformanceCursorResponse>> getUpcomingByLocationWithCursor(
+            @PathVariable Long performanceLocationId,
+            @RequestParam(required = false) LocalDateTime cursorTime,
+            @RequestParam(required = false) Long cursorId,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        CursorResponse<PerformanceCursorResponse> response =
+                performanceService.getUpcomingByLocationWithCursor(
+                        performanceLocationId,
+                        cursorTime,
+                        cursorId,
+                        size
+                );
+
+        return ResponseEntity.ok(response);
+    }
+
 }

--- a/src/main/java/team/unibusk/backend/domain/performance/presentation/PerformanceDocsController.java
+++ b/src/main/java/team/unibusk/backend/domain/performance/presentation/PerformanceDocsController.java
@@ -23,8 +23,10 @@ import team.unibusk.backend.domain.performance.presentation.request.PerformanceU
 import team.unibusk.backend.global.annotation.MemberId;
 import team.unibusk.backend.global.annotation.SwaggerBody;
 import team.unibusk.backend.global.exception.ExceptionResponse;
+import team.unibusk.backend.global.response.CursorResponse;
 import team.unibusk.backend.global.response.PageResponse;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Tag(name = "Performance", description = "공연 관련 API")
@@ -167,4 +169,33 @@ public interface PerformanceDocsController{
             )
             Pageable pageable
     );
+
+    @Operation(
+            summary = "공연 장소별 다가오는 공연 커서 조회",
+            description = """
+                특정 공연 장소의 다가오는 공연을 커서 기반으로 조회합니다.
+
+                최초 호출 시 cursorTime, cursorId 없이 요청합니다.
+
+                다음 페이지 요청 시 응답으로 받은 nextCursorTime, nextCursorId 를 그대로 전달하면 됩니다.
+                """
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "공연 목록 조회 성공"),
+    })
+    @GetMapping("/locations/{performanceLocationId}/upcoming")
+    ResponseEntity<CursorResponse<PerformanceCursorResponse>> getUpcomingByLocationWithCursor(
+            @Parameter(description = "공연 장소 ID", example = "1")
+            @PathVariable Long performanceLocationId,
+
+            @Parameter(description = "다음 페이지 커서 시간 (응답값 그대로 사용)", example = "2026-02-02T19:05:15.716")
+            @RequestParam(required = false) LocalDateTime cursorTime,
+
+            @Parameter(description = "다음 페이지 커서 ID (응답값 그대로 사용)", example = "23")
+            @RequestParam(required = false) Long cursorId,
+
+            @Parameter(description = "조회 개수", example = "10")
+            @RequestParam(defaultValue = "10") int size
+    );
+
 }

--- a/src/main/java/team/unibusk/backend/global/response/CursorResponse.java
+++ b/src/main/java/team/unibusk/backend/global/response/CursorResponse.java
@@ -1,0 +1,35 @@
+package team.unibusk.backend.global.response;
+
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Builder
+public record CursorResponse<T>(
+
+        List<T> content,
+
+        LocalDateTime nextCursorTime,
+
+        Long nextCursorId,
+
+        boolean hasNext
+
+) {
+
+    public static <T> CursorResponse<T> of(
+            List<T> content,
+            LocalDateTime nextTime,
+            Long nextId,
+            boolean hasNext
+    ) {
+        return CursorResponse.<T>builder()
+                .content(content)
+                .nextCursorTime(nextTime)
+                .nextCursorId(nextId)
+                .hasNext(hasNext)
+                .build();
+    }
+
+}


### PR DESCRIPTION
## 관련 이슈
- #100 

## Summary

특정 버스킹 장소의 다가오는 공연 커서 기반 조회 기능을 구현했습니다.

## Tasks

- 공연 장소별 다가오는 공연 커서 기반 조회 API 구현
- QueryDSL 기반 커서 페이징 쿼리 작성 (startTime + id)
- PerformanceCursorResponse DTO 추가
- 공통 CursorResponse 구조 도입
- PerformanceController 엔드포인트 추가
- Swagger 문서화


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 특정 장소의 예정된 공연을 커서 기반 페이지네이션으로 조회할 수 있는 새로운 API 엔드포인트 추가
  * 커서 기반 페이지네이션을 통한 효율적인 데이터 로딩 지원
  * 공연의 제목, 날짜, 시작/종료 시간, 이미지 등 상세 정보 포함

<!-- end of auto-generated comment: release notes by coderabbit.ai -->