### PR TITLE
Fix: 이미지 파일 매칭을 확장자 무시로 변경

### DIFF
--- a/src/main/java/team/unibusk/backend/domain/performanceLocation/application/PerformanceLocationExcelService.java
+++ b/src/main/java/team/unibusk/backend/domain/performanceLocation/application/PerformanceLocationExcelService.java
@@ -145,9 +145,13 @@ public class PerformanceLocationExcelService {
     }
 
     private MultipartFile getMatchedImageFile(String imageUrl, Map<String, MultipartFile> imageMap) {
-        MultipartFile file = imageMap.get(imageUrl);
-        if (file == null) throw new RuntimeException("폴더 내에 '" + imageUrl + "' 파일이 없습니다.");
-        return file;
+        for (Map.Entry<String, MultipartFile> entry : imageMap.entrySet()) {
+            String fileName = entry.getKey();
+            if (fileName.startsWith(imageUrl)) {
+                return entry.getValue();
+            }
+        }
+        throw new RuntimeException("폴더 내에 '" + imageUrl + "' 파일이 없습니다.");
     }
 
     private void validateRequiredFields(UploadDto dto) {


### PR DESCRIPTION
## 관련 이슈
- 관련 이슈 태그해주세요.

## Summary

이미지 파일 매칭을 확장자 무시로 변경하여 엑셀 업로드 시 image1.jpg 파일을 image1 문자열로 정확히 매칭


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **버그 수정**
  * 공연 위치 이미지 파일 검색 로직을 개선하여 더욱 유연한 매칭이 가능하도록 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->