### PR TITLE
Feat: 내가 등록한 공연 정보 조회 기능 구현

### DIFF
--- a/src/main/java/team/unibusk/backend/domain/performance/application/dto/response/MyPerformanceSummaryResponse.java
+++ b/src/main/java/team/unibusk/backend/domain/performance/application/dto/response/MyPerformanceSummaryResponse.java
@@ -1,0 +1,61 @@
+package team.unibusk.backend.domain.performance.application.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import team.unibusk.backend.domain.performance.domain.Performance;
+import team.unibusk.backend.domain.performance.domain.PerformanceImage;
+import team.unibusk.backend.domain.performanceLocation.domain.PerformanceLocation;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Builder
+@Schema(description = "내 공연 요약 응답 DTO")
+public record MyPerformanceSummaryResponse(
+
+        @Schema(description = "공연 ID", example = "12")
+        Long performanceId,
+
+        @Schema(description = "회원 ID", example = "3")
+        Long memberId,
+
+        @Schema(description = "공연 제목", example = "홍대 버스킹 공연")
+        String title,
+
+        @Schema(description = "공연 시작 시간", example = "2026-02-10T18:00:00")
+        LocalDateTime startTime,
+
+        @Schema(description = "공연 종료 시간", example = "2026-02-10T20:00:00")
+        LocalDateTime endTime,
+
+        @Schema(description = "공연 장소 이름", example = "홍대 걷고싶은거리")
+        String performanceLocationName,
+
+        @Schema(
+                description = "공연 이미지 URL 리스트",
+                example = "[\"https://image1.jpg\", \"https://image2.jpg\"]"
+        )
+        List<String> imageUrls
+
+) {
+
+    public static MyPerformanceSummaryResponse from(
+            Performance performance,
+            PerformanceLocation performanceLocation
+    ) {
+        return MyPerformanceSummaryResponse.builder()
+                .performanceId(performance.getId())
+                .memberId(performance.getMemberId())
+                .title(performance.getTitle())
+                .startTime(performance.getStartTime())
+                .endTime(performance.getEndTime())
+                .performanceLocationName(performanceLocation.getName())
+                .imageUrls(
+                        performance.getImages().stream()
+                                .map(PerformanceImage::getImageUrl)
+                                .toList()
+                )
+                .build();
+    }
+
+}

--- a/src/main/java/team/unibusk/backend/domain/performance/domain/PerformanceRepository.java
+++ b/src/main/java/team/unibusk/backend/domain/performance/domain/PerformanceRepository.java
@@ -45,4 +45,10 @@ public interface PerformanceRepository {
             int size
     );
 
+    List<Performance> findMyPerformancesWithCursor(
+            Long memberId,
+            Long cursorId,
+            int size
+    );
+
 }

--- a/src/main/java/team/unibusk/backend/domain/performance/infrastructure/PerformanceQueryDslRepository.java
+++ b/src/main/java/team/unibusk/backend/domain/performance/infrastructure/PerformanceQueryDslRepository.java
@@ -16,6 +16,7 @@ import team.unibusk.backend.domain.performance.application.dto.response.Performa
 import team.unibusk.backend.domain.performance.domain.Performance;
 import team.unibusk.backend.domain.performance.domain.PerformanceStatus;
 import team.unibusk.backend.domain.performance.domain.QPerformance;
+import team.unibusk.backend.domain.performance.domain.QPerformanceImage;
 
 import static team.unibusk.backend.domain.performance.domain.QPerformance.performance;
 import static team.unibusk.backend.domain.performanceLocation.domain.QPerformanceLocation.performanceLocation;
@@ -101,6 +102,30 @@ public class PerformanceQueryDslRepository {
                 .fetch();
     }
 
+    public List<Performance> findMyPerformancesWithCursor(
+            Long memberId,
+            Long cursorId,
+            int size
+    ) {
+        QPerformance p = QPerformance.performance;
+        QPerformanceImage i = QPerformanceImage.performanceImage;
+
+        return queryFactory
+                .selectDistinct(p)
+                .from(p)
+                .leftJoin(p.images, i).fetchJoin()
+                .where(
+                        p.memberId.eq(memberId),
+                        cursorIdLt(p, cursorId)
+                )
+                .orderBy(p.id.desc())
+                .limit(size + 1)
+                .fetch();
+    }
+
+    private BooleanExpression cursorIdLt(QPerformance p, Long cursorId) {
+        return cursorId == null ? null : p.id.lt(cursorId);
+    }
 
     private BooleanExpression upcomingAtPerformanceLocation(
             QPerformance p,

--- a/src/main/java/team/unibusk/backend/domain/performance/infrastructure/PerformanceRepositoryImpl.java
+++ b/src/main/java/team/unibusk/backend/domain/performance/infrastructure/PerformanceRepositoryImpl.java
@@ -84,4 +84,13 @@ public class PerformanceRepositoryImpl implements PerformanceRepository {
                 .findPastByPerformanceLocationWithCursor(performanceLocationId, cursorTime, cursorId, size);
     }
 
+    @Override
+    public List<Performance> findMyPerformancesWithCursor(
+            Long memberId,
+            Long cursorId,
+            int size
+    ) {
+        return performanceQueryDslRepository.findMyPerformancesWithCursor(memberId, cursorId, size);
+    }
+
 }

--- a/src/main/java/team/unibusk/backend/domain/performance/presentation/PerformanceController.java
+++ b/src/main/java/team/unibusk/backend/domain/performance/presentation/PerformanceController.java
@@ -180,4 +180,13 @@ public class PerformanceController implements PerformanceDocsController{
         return ResponseEntity.status(200).body(response);
     }
 
+    @GetMapping("/me")
+    public CursorResponse<MyPerformanceSummaryResponse> myPerformances(
+            @MemberId Long memberId,
+            @RequestParam(required = false) Long cursorId,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        return performanceService.getMyPerformances(memberId, cursorId, size);
+    }
+
 }

--- a/src/main/java/team/unibusk/backend/domain/performance/presentation/PerformanceDocsController.java
+++ b/src/main/java/team/unibusk/backend/domain/performance/presentation/PerformanceDocsController.java
@@ -226,4 +226,31 @@ public interface PerformanceDocsController{
             @RequestParam(defaultValue = "10") int size
     );
 
+    @Operation(
+            summary = "내 공연 목록 커서 조회",
+            description = """
+            로그인한 사용자가 등록한 공연 목록을 커서 기반으로 조회합니다.
+
+            최초 호출 시 cursorId 없이 요청합니다.
+
+            다음 페이지 요청 시 응답으로 받은 nextCursorId 를 그대로 전달하면 됩니다.
+            """
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "내 공연 목록 조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자",
+                    content = @Content(schema = @Schema(implementation = ExceptionResponse.class)))
+    })
+    @GetMapping("/me")
+    CursorResponse<MyPerformanceSummaryResponse> myPerformances(
+            @Parameter(hidden = true)
+            @MemberId Long memberId,
+
+            @Parameter(description = "다음 페이지 커서 ID (응답값 그대로 사용)", example = "23")
+            @RequestParam(required = false) Long cursorId,
+
+            @Parameter(description = "조회 개수", example = "10")
+            @RequestParam(defaultValue = "10") int size
+    );
+
 }


### PR DESCRIPTION
## 관련 이슈
- #109 

## Summary

내가 등록한 공연 정보 조회 기능을 구현했습니다.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 사용자가 자신의 공연 목록을 조회할 수 있는 새로운 기능 추가
  * 커서 기반 페이지네이션으로 효율적인 데이터 로딩 지원
  * 공연 제목, 일정, 장소, 이미지 등 상세 정보 표시

<!-- end of auto-generated comment: release notes by coderabbit.ai -->