### PR TITLE
Feat: S3 업로드 시 이미지 파일 형식 검증 로직 추가

### DIFF
--- a/src/main/java/team/unibusk/backend/global/file/infrastructure/S3FileStorageAdapter.java
+++ b/src/main/java/team/unibusk/backend/global/file/infrastructure/S3FileStorageAdapter.java
@@ -18,6 +18,7 @@ import team.unibusk.backend.global.file.presentation.exception.InvalidFileUrlExc
 import java.io.IOException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.util.Set;
 import java.util.UUID;
 
 @Component
@@ -31,6 +32,8 @@ public class S3FileStorageAdapter implements FileStoragePort {
 
     @Value("${cloud.aws.s3.public-url:https://%s.s3.amazonaws.com}")
     private String publicUrlFormat;
+
+    private static final Set<String> ALLOWED_EXTENSIONS = Set.of("jpg", "jpeg", "png");
 
     @Override
     public String upload(MultipartFile file, String folder) {
@@ -83,7 +86,15 @@ public class S3FileStorageAdapter implements FileStoragePort {
         if (filename == null || !filename.contains(".") || filename.endsWith(".")) {
             throw new InvalidFileTypeException();
         }
-        return filename.substring(filename.lastIndexOf('.') + 1);
+
+        String extension = filename.substring(filename.lastIndexOf('.') + 1)
+                .toLowerCase();
+
+        if (!ALLOWED_EXTENSIONS.contains(extension)) {
+            throw new InvalidFileTypeException();
+        }
+
+        return extension;
     }
 
     private String getPublicUrl(String key) {


### PR DESCRIPTION
## 관련 이슈
- #111 

## Summary

S3 파일 업로드 시 허용된 이미지 형식만 업로드할 수 있도록 검증 로직을 추가했습니다.
JPG, JPEG, PNG 이외의 확장자는 업로드 시 예외가 발생하도록 처리했습니다.

## Tasks

- S3 업로드 시 이미지 확장자(JPG, JPEG, PNG) 검증 로직 추가
- 허용되지 않은 확장자 업로드 시 InvalidFileTypeException 발생하도록 처리

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* 파일 업로드 검증이 강화되었습니다. 이제 JPG, JPEG, PNG 형식의 이미지 파일만 업로드 가능하며, 허용되지 않는 파일 형식은 업로드 시 거부됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->