### PR TITLE
Fix: OAuth 인증 실패 시 context-path 중복 리다이렉트 문제 해결

### DIFF
--- a/src/main/java/team/unibusk/backend/global/auth/presentation/security/handler/CustomAuthenticationFailureHandler.java
+++ b/src/main/java/team/unibusk/backend/global/auth/presentation/security/handler/CustomAuthenticationFailureHandler.java
@@ -1,6 +1,5 @@
 package team.unibusk.backend.global.auth.presentation.security.handler;
 
-import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -31,8 +30,19 @@ public class CustomAuthenticationFailureHandler extends SimpleUrlAuthenticationF
     ) throws IOException {
         log.warn("Authentication failure: {}", exception.getMessage());
 
-        String exceptionParam = URLEncoder.encode(String.valueOf(AUTHENTICATION_REQUIRED), StandardCharsets.UTF_8);
-        String failureUrl = securityProperties.oAuthUrl().loginUrl() + "?error=true&exception=" + exceptionParam;
+        String exceptionParam = URLEncoder.encode(
+                String.valueOf(AUTHENTICATION_REQUIRED),
+                StandardCharsets.UTF_8
+        );
+
+        String contextPath = request.getContextPath();
+        String loginUrl = securityProperties.oAuthUrl().loginUrl();
+
+        String cleanLoginUrl = loginUrl.startsWith(contextPath)
+                ? loginUrl.substring(contextPath.length())
+                : loginUrl;
+
+        String failureUrl = cleanLoginUrl + "?error=true&exception=" + exceptionParam;
 
         getRedirectStrategy().sendRedirect(request, response, failureUrl);
     }


### PR DESCRIPTION
## 관련 이슈
- #140 
## Summary

OAuth 인증 실패 시 context-path가 중복으로 추가되어 `/api/api/auths/login`으로 잘못된 경로로 리다이렉트되던 문제를 수정했습니다. CustomAuthenticationFailureHandler에서 리다이렉트 URL 생성 시 context-path 중복을 방지하도록 개선했습니다.

## Tasks
- CustomAuthenticationFailureHandler에서 리다이렉트 URL 생성 로직 개선
- loginUrl에 이미 context-path가 포함된 경우 제거하는 로직 추가
- OAuth 인증 실패 시 올바른 경로(`/api/auths/login`)로 리다이렉트되도록 수정
