### PR TITLE
Infra: Nginx Rate Limiting 적용으로 DDoS 공격 방어

### DIFF
--- a/deployment/prod/nginx/unibusk-blue.conf
+++ b/deployment/prod/nginx/unibusk-blue.conf
@@ -1,5 +1,4 @@
 limit_req_zone $binary_remote_addr zone=api_general:10m rate=50r/s;
-limit_conn_zone $binary_remote_addr zone=conn_limit:10m;
 
 upstream backend_blue {
     server 127.0.0.1:8081;
@@ -41,7 +40,6 @@ server {
 
     location /api/ {
         limit_req zone=api_general burst=100 nodelay;
-        limit_conn conn_limit 20;
         limit_req_status 429;
 
         proxy_pass http://backend_blue;

--- a/deployment/prod/nginx/unibusk-green.conf
+++ b/deployment/prod/nginx/unibusk-green.conf
@@ -1,5 +1,4 @@
 limit_req_zone $binary_remote_addr zone=api_general:10m rate=50r/s;
-limit_conn_zone $binary_remote_addr zone=conn_limit:10m;
 
 upstream backend_green {
     server 127.0.0.1:8082;
@@ -41,7 +40,6 @@ server {
 
     location /api/ {
         limit_req zone=api_general burst=100 nodelay;
-        limit_conn conn_limit 20;
         limit_req_status 429;
 
         proxy_pass http://backend_green;


### PR DESCRIPTION
## 관련 이슈
- #143 

## Summary
Nginx Rate Limiting을 적용하여 DDoS 공격 및 대량 트래픽으로부터 서버를 보호합니다. 
모든 API 엔드포인트에 대해 IP별로 초당 요청 수 제한을 적용하여 서버 안정성을 확보했습니다.

## Tasks
- Nginx Rate Limiting 설정 추가 (IP당 초당 50개 요청, burst 100)
- /api/ 경로 전체에 Rate Limiting 적용
- DDoS 방어를 위한 타임아웃 설정 (10초 제한)
- Rate Limit 초과 시 429 JSON 에러 응답 반환

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * API에 전역 속도 제한 및 요청 버스트 제어 추가
  * 속도 초과 시 표준화된 JSON 429 오류 응답 제공
  * API 프록시의 연결/전송/수신 타임아웃과 서버 수준의 클라이언트 타임아웃/keepalive 설정 강화
  * 프록시 헤더 처리 방식 정비로 헤더 전달 흐름 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->