### PR TITLE
Infra: Grafana 리버스 프록시 설정 추가

### DIFF
--- a/deployment/prod/nginx/unibusk-blue.conf
+++ b/deployment/prod/nginx/unibusk-blue.conf
@@ -55,6 +55,14 @@ server {
         proxy_read_timeout 10s;
     }
 
+    location /grafana/ {
+        proxy_pass http://127.0.0.1:3000/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
     error_page 429 /429.json;
     location = /429.json {
         internal;

--- a/deployment/prod/nginx/unibusk-green.conf
+++ b/deployment/prod/nginx/unibusk-green.conf
@@ -55,6 +55,14 @@ server {
         proxy_read_timeout 10s;
     }
 
+    location /grafana/ {
+        proxy_pass http://127.0.0.1:3000/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
     error_page 429 /429.json;
     location = /429.json {
         internal;


### PR DESCRIPTION
## 관련 이슈
- 없음

## Summary
Grafana 대시보드 외부 접근을 위한 Nginx 리버스 프록시 설정을 추가했습니다.

## Tasks
- Blue/Green Nginx 설정에 `/grafana/` location 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* 프로덕션 환경 인프라스트럭처에 모니터링 도구 접근 경로가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->