### PR TITLE
Fix: ObjectMapper import를 Jackson 3.x(tools.jackson)로 수정

### DIFF
--- a/src/main/java/team/unibusk/backend/global/auth/presentation/security/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/team/unibusk/backend/global/auth/presentation/security/JwtAuthenticationEntryPoint.java
@@ -1,6 +1,5 @@
 package team.unibusk.backend.global.auth.presentation.security;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.AuthenticationException;
@@ -10,6 +9,7 @@ import org.springframework.stereotype.Component;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import team.unibusk.backend.global.exception.ExceptionResponse;
+import tools.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
 


### PR DESCRIPTION
## 관련 이슈
- #168

## Summary
Spring Boot 4.x 환경에서 `ObjectMapper` 빈을 찾지 못해 애플리케이션이 기동되지 않는 문제를 수정했습니다.

## Tasks
- `com.fasterxml.jackson.databind.ObjectMapper` → `tools.jackson.databind.ObjectMapper` 로 import 변경
- Spring Boot 4.x는 Jackson 3.x(`tools.jackson`) 기반으로 변경되어 기존 `com.fasterxml` 패키지의 빈이 자동 등록되지 않는 문제 대응