### PR TITLE
Fix: GET /performances/me 인증 설정 누락 추가

### DIFF
--- a/src/main/java/team/unibusk/backend/global/config/SecurityConfig.java
+++ b/src/main/java/team/unibusk/backend/global/config/SecurityConfig.java
@@ -128,6 +128,7 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.POST, "/performances").authenticated()
                         .requestMatchers(HttpMethod.PATCH, "/performances/*").authenticated()
                         .requestMatchers(HttpMethod.DELETE, "/performances/*").authenticated()
+                        .requestMatchers(HttpMethod.GET, "/performances/me").authenticated()
                         .requestMatchers("/members/**").authenticated()
                         .requestMatchers("/auths/logout").authenticated()
                         .anyRequest().permitAll()


### PR DESCRIPTION
## 관련 이슈
- #180 

## Summary

`GET /performances/me` 엔드포인트가 `@MemberId`를 사용함에도 불구하고 `SecurityConfig`에 인증 설정이 누락되어 있어 수정합니다.

## Tasks

- `SecurityConfig`에 `GET /performances/me` 인증 설정 추가


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 한 줄 요약
`SecurityConfig`의 `configureApiAuthorization` 메서드에 `GET /performances/me` 엔드포인트에 대한 인증 요구 설정을 추가했습니다.

## ⚙️ 설정

### `SecurityConfig.configureApiAuthorization` 메서드에 `GET /performances/me` 인증 규칙 추가
- **변경 내용**: 131번 라인에 `.requestMatchers(HttpMethod.GET, "/performances/me").authenticated()` 규칙 추가
- **변경 이유**: `GET /performances/me` 엔드포인트가 컨트롤러에서 `@MemberId` 어노테이션을 통해 현재 인증된 사용자 정보를 참조하는데, 보안 설정에서 이 엔드포인트에 대한 인증 요구 설정이 누락되어 있어서 비인증 사용자도 접근 가능한 상태였습니다.
- **효과**: 이제 `GET /performances/me` 엔드포인트는 인증된 사용자만 접근할 수 있으므로 비인증 요청으로 인한 NullPointerException 등의 예외 상황을 방지할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->