### PR TITLE
Test: ControllerTestSupport 필터 의존성 제거 및 excludeFilters 정리

### DIFF
--- a/src/test/java/team/unibusk/backend/domain/member/presentation/MemberControllerTest.java
+++ b/src/test/java/team/unibusk/backend/domain/member/presentation/MemberControllerTest.java
@@ -2,16 +2,11 @@ package team.unibusk.backend.domain.member.presentation;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
-import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.FilterType;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import team.unibusk.backend.domain.member.application.dto.response.MemberInfoResponse;
 import team.unibusk.backend.domain.member.application.dto.response.MemberNameUpdateResponse;
 import team.unibusk.backend.domain.member.presentation.request.MemberNameUpdateRequest;
-import team.unibusk.backend.global.auth.presentation.security.RedirectUrlFilter;
-import team.unibusk.backend.global.jwt.filter.JwtTokenFilter;
-import team.unibusk.backend.global.logging.filter.MdcFilter;
 import team.unibusk.backend.global.support.ControllerTestSupport;
 import team.unibusk.backend.global.support.TestMember;
 
@@ -20,13 +15,7 @@ import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verifyNoInteractions;
 
-@WebMvcTest(
-        controllers = {MemberController.class},
-        excludeFilters = @ComponentScan.Filter(
-                type = FilterType.ASSIGNABLE_TYPE,
-                classes = {JwtTokenFilter.class, MdcFilter.class, RedirectUrlFilter.class}
-        )
-)
+@WebMvcTest(controllers = {MemberController.class})
 class MemberControllerTest extends ControllerTestSupport {
 
     @Test

--- a/src/test/java/team/unibusk/backend/global/auth/presentation/AuthControllerTest.java
+++ b/src/test/java/team/unibusk/backend/global/auth/presentation/AuthControllerTest.java
@@ -7,6 +7,7 @@ import org.springframework.http.MediaType;
 import team.unibusk.backend.global.auth.application.dto.response.LoginResultResponse;
 import team.unibusk.backend.global.auth.presentation.request.AuthCodeExchangeRequest;
 import team.unibusk.backend.global.support.ControllerTestSupport;
+import team.unibusk.backend.global.support.TestMember;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -64,6 +65,7 @@ class AuthControllerTest extends ControllerTestSupport {
     }
 
     @Test
+    @TestMember
     void 로그아웃_요청_시_200이_반환된다() {
         willDoNothing().given(authService).logout(any(), any());
 

--- a/src/test/java/team/unibusk/backend/global/support/ControllerTestSupport.java
+++ b/src/test/java/team/unibusk/backend/global/support/ControllerTestSupport.java
@@ -2,17 +2,13 @@ package team.unibusk.backend.global.support;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
-import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.assertj.MockMvcTester;
 import org.springframework.validation.beanvalidation.MethodValidationPostProcessor;
 import team.unibusk.backend.domain.member.application.MemberService;
 import team.unibusk.backend.global.auth.application.auth.AuthService;
-import team.unibusk.backend.global.auth.application.refreshtoken.RefreshTokenService;
 import team.unibusk.backend.global.config.TestSecurityConfig;
-import team.unibusk.backend.global.jwt.injector.TokenInjector;
-import team.unibusk.backend.global.jwt.resolver.JwtTokenResolver;
 import team.unibusk.backend.global.logging.filter.TraceIdResolver;
 import tools.jackson.databind.ObjectMapper;
 
@@ -28,18 +24,6 @@ public abstract class ControllerTestSupport {
 
     @MockitoBean
     protected AuthService authService;
-
-    @MockitoBean
-    protected TokenInjector tokenInjector;
-
-    @MockitoBean
-    protected JwtTokenResolver jwtTokenResolver;
-
-    @MockitoBean
-    protected UserDetailsService userDetailsService;
-
-    @MockitoBean
-    protected RefreshTokenService refreshTokenService;
 
     @MockitoBean
     protected TraceIdResolver traceIdResolver;


### PR DESCRIPTION
## 관련 이슈
- #182 

## Summary

`JwtTokenFilter`, `RedirectUrlFilter`의 `@Component` 제거로 인해 불필요해진 필터 관련 mock 의존성을 `ControllerTestSupport`에서 제거하고, `excludeFilters` 설정을 정리합니다.

## Tasks

- `ControllerTestSupport`에서 필터 관련 `@MockitoBean` 제거 (`TokenInjector`, `JwtTokenResolver`, `UserDetailsService`, `RefreshTokenService`)
- `MemberControllerTest`에서 `excludeFilters` 제거
- `AuthControllerTest` 로그아웃 테스트에 `@TestMember` 추가


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## JwtTokenFilter와 RedirectUrlFilter의 @Component 제거로 인한 테스트 필터 의존성 정리

### 🗑️ 제거

**ControllerTestSupport에서 불필요한 @MockitoBean 필드 제거**
- `TokenInjector` @MockitoBean 필드 제거
- `JwtTokenResolver` @MockitoBean 필드 제거
- `UserDetailsService` @MockitoBean 필드 제거
- `RefreshTokenService` @MockitoBean 필드 제거
- 관련 import 문 4개 제거

**변경 이유**: PR #179에서 `JwtTokenFilter`와 `RedirectUrlFilter`의 `@Component` 어노테이션이 제거되고 명시적 Bean 등록 방식으로 변경되었으므로, 이들을 auto-wiring하기 위한 mock 의존성이 더 이상 필요하지 않음. 이를 통해 테스트 기반 클래스의 의존성을 단순화하여 테스트 유지보수성 향상.

**MemberControllerTest의 excludeFilters 제거**
- `@WebMvcTest` 어노테이션에서 `excludeFilters` 속성 제거
- `ComponentScan.Filter` 설정 제거 (JwtTokenFilter, MdcFilter, RedirectUrlFilter 필터링)
- 관련 import 2개 제거 (`ComponentScan`, `FilterType`)

**변경 이유**: 필터들이 `@Component`로 등록되지 않으므로 명시적으로 제외할 필요가 없음. `@WebMvcTest`가 자동으로 필터를 로드하지 않으므로 설정을 단순화할 수 있음.

### ✨ 추가

**AuthControllerTest의 로그아웃 테스트에 @TestMember 추가**
- `로그아웃_요청_시_200이_반환된다` 테스트 메서드에 `@TestMember` 어노테이션 추가
- `TestMember` import 추가

**변경 이유**: 로그아웃 기능은 인증된 사용자 컨텍스트에서만 실행되므로, 테스트에 사용자 정보를 주입하기 위해 어노테이션 추가. 이를 통해 테스트의 의도를 명확하게 표현.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->