### PR TITLE
Fix: blue-green 배포 MySQL/Redis 연결을 위한 host.docker.internal 추가

### DIFF
--- a/deployment/prod/docker/docker-compose.yml
+++ b/deployment/prod/docker/docker-compose.yml
@@ -5,8 +5,12 @@ services:
     image: ${DOCKER_USERNAME}/${IMAGE_NAME}:${IMAGE_TAG}
     container_name: unibusk-blue
     stop_grace_period: 35s
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     environment:
       - SPRING_PROFILES_ACTIVE=prod
+      - DB_HOST=host.docker.internal
+      - REDIS_HOST=host.docker.internal
     ports:
       - "8081:8080"
     env_file:
@@ -25,8 +29,12 @@ services:
     image: ${DOCKER_USERNAME}/${IMAGE_NAME}:${IMAGE_TAG}
     container_name: unibusk-green
     stop_grace_period: 35s
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     environment:
       - SPRING_PROFILES_ACTIVE=prod
+      - DB_HOST=host.docker.internal
+      - REDIS_HOST=host.docker.internal
     ports:
       - "8082:8080"
     env_file:


### PR DESCRIPTION
## 관련 이슈
- #194

## Summary
도커 컨테이너 환경에서 MySQL/Redis에 연결할 수 없는 문제 수정
컨테이너 내부에서 localhost는 호스트 서버가 아닌 컨테이너 자신을 가리키기 때문에 host.docker.internal로 연결하도록 변경

## Tasks
- docker-compose-blue.yml에 extra_hosts 및 DB_HOST, REDIS_HOST 환경변수 추가
- docker-compose-green.yml에 extra_hosts 및 DB_HOST, REDIS_HOST 환경변수 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Docker 컨테이너 내부에서 호스트의 MySQL/Redis에 연결할 수 있도록 `host.docker.internal` 설정 추가

## ⚙️ 설정

**`deployment/prod/docker/docker-compose.yml`**의 `blue`, `green` 서비스:
- `extra_hosts: ["host.docker.internal:host-gateway"]` 추가 - Docker 컨테이너 내에서 `host.docker.internal`이 호스트 머신의 IP로 해석되도록 설정
- 환경변수 `DB_HOST=host.docker.internal` 추가 - MySQL이 호스트 머신에서 실행 중일 때 컨테이너에서 접근 가능하도록 변경
- 환경변수 `REDIS_HOST=host.docker.internal` 추가 - Redis가 호스트 머신에서 실행 중일 때 컨테이너에서 접근 가능하도록 변경

**변경 이유**: 컨테이너 내부에서 `localhost`는 컨테이너 자신을 가리키므로, 호스트의 데이터베이스와 캐시에 접근하기 위해 `host.docker.internal`을 사용하여 host-gateway를 통해 접근하도록 구성. 이를 통해 Blue-Green 배포 환경에서 양쪽 컨테이너가 호스트의 MySQL/Redis와 정상적으로 연결 가능.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->