### PR TITLE
Test: ApplicationGuide 테스트 코드 작성

### DIFF
--- a/src/test/java/team/unibusk/backend/domain/applicationguide/application/ApplicationGuideServiceTest.java
+++ b/src/test/java/team/unibusk/backend/domain/applicationguide/application/ApplicationGuideServiceTest.java
@@ -82,6 +82,9 @@ class ApplicationGuideServiceTest extends UnitTestSupport {
 
         assertThatThrownBy(() -> applicationGuideService.getApplicationGuides(performanceLocationId))
                 .isInstanceOf(PerformanceLocationNotFoundException.class);
+
+        then(performanceLocationRepository).should().findById(performanceLocationId);
+        then(applicationGuideRepository).shouldHaveNoInteractions();
     }
 
 }

--- a/src/test/java/team/unibusk/backend/domain/applicationguide/application/ApplicationGuideServiceTest.java
+++ b/src/test/java/team/unibusk/backend/domain/applicationguide/application/ApplicationGuideServiceTest.java
@@ -71,6 +71,9 @@ class ApplicationGuideServiceTest extends UnitTestSupport {
                 applicationGuideService.getApplicationGuides(performanceLocationId);
 
         assertThat(response.applicationGuideResponses()).isEmpty();
+
+        then(performanceLocationRepository).should().findById(performanceLocationId);
+        then(applicationGuideRepository).should().findAllByPerformanceLocationId(performanceLocationId);
     }
 
     @Test

--- a/src/test/java/team/unibusk/backend/domain/applicationguide/application/ApplicationGuideServiceTest.java
+++ b/src/test/java/team/unibusk/backend/domain/applicationguide/application/ApplicationGuideServiceTest.java
@@ -1,0 +1,87 @@
+package team.unibusk.backend.domain.applicationguide.application;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.test.util.ReflectionTestUtils;
+import team.unibusk.backend.domain.applicationguide.application.dto.response.ApplicationGuideListResponse;
+import team.unibusk.backend.domain.applicationguide.domain.ApplicationGuide;
+import team.unibusk.backend.domain.applicationguide.domain.ApplicationGuideRepository;
+import team.unibusk.backend.domain.performance.presentation.exception.PerformanceLocationNotFoundException;
+import team.unibusk.backend.domain.performanceLocation.domain.PerformanceLocation;
+import team.unibusk.backend.domain.performanceLocation.domain.PerformanceLocationFixture;
+import team.unibusk.backend.domain.performanceLocation.domain.PerformanceLocationRepository;
+import team.unibusk.backend.global.support.UnitTestSupport;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+class ApplicationGuideServiceTest extends UnitTestSupport {
+
+    @InjectMocks
+    private ApplicationGuideService applicationGuideService;
+
+    @Mock
+    private ApplicationGuideRepository applicationGuideRepository;
+
+    @Mock
+    private PerformanceLocationRepository performanceLocationRepository;
+
+    @Test
+    void 신청_가이드_목록을_정상_조회한다() {
+        Long performanceLocationId = 1L;
+
+        PerformanceLocation location = PerformanceLocationFixture.createLocation(performanceLocationId, "홍대");
+
+        ApplicationGuide guide1 = ApplicationGuide.create("사전 신청 필수", location);
+        ApplicationGuide guide2 = ApplicationGuide.create("장비 직접 지참", location);
+        ReflectionTestUtils.setField(guide1, "id", 1L);
+        ReflectionTestUtils.setField(guide2, "id", 2L);
+
+        given(performanceLocationRepository.findById(performanceLocationId)).willReturn(location);
+        given(applicationGuideRepository.findAllByPerformanceLocationId(performanceLocationId))
+                .willReturn(List.of(guide1, guide2));
+
+        ApplicationGuideListResponse response =
+                applicationGuideService.getApplicationGuides(performanceLocationId);
+
+        assertThat(response.applicationGuideResponses()).hasSize(2);
+        assertThat(response.applicationGuideResponses().get(0).content()).isEqualTo("사전 신청 필수");
+        assertThat(response.applicationGuideResponses().get(1).content()).isEqualTo("장비 직접 지참");
+
+        then(performanceLocationRepository).should().findById(performanceLocationId);
+        then(applicationGuideRepository).should().findAllByPerformanceLocationId(performanceLocationId);
+    }
+
+    @Test
+    void 신청_가이드가_없으면_빈_목록을_반환한다() {
+        Long performanceLocationId = 1L;
+
+        PerformanceLocation location = PerformanceLocationFixture.createLocation(performanceLocationId, "홍대");
+
+        given(performanceLocationRepository.findById(performanceLocationId)).willReturn(location);
+        given(applicationGuideRepository.findAllByPerformanceLocationId(performanceLocationId))
+                .willReturn(List.of());
+
+        ApplicationGuideListResponse response =
+                applicationGuideService.getApplicationGuides(performanceLocationId);
+
+        assertThat(response.applicationGuideResponses()).isEmpty();
+    }
+
+    @Test
+    void 존재하지_않는_장소_ID로_조회하면_예외가_발생한다() {
+        Long performanceLocationId = 999L;
+
+        given(performanceLocationRepository.findById(performanceLocationId))
+                .willThrow(PerformanceLocationNotFoundException.class);
+
+        assertThatThrownBy(() -> applicationGuideService.getApplicationGuides(performanceLocationId))
+                .isInstanceOf(PerformanceLocationNotFoundException.class);
+    }
+
+}

--- a/src/test/java/team/unibusk/backend/domain/applicationguide/presentation/ApplicationGuideControllerTest.java
+++ b/src/test/java/team/unibusk/backend/domain/applicationguide/presentation/ApplicationGuideControllerTest.java
@@ -1,0 +1,66 @@
+package team.unibusk.backend.domain.applicationguide.presentation;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import team.unibusk.backend.domain.applicationguide.application.dto.response.ApplicationGuideListResponse;
+import team.unibusk.backend.domain.applicationguide.application.dto.response.ApplicationGuideResponse;
+import team.unibusk.backend.global.support.ControllerTestSupport;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+@WebMvcTest(controllers = ApplicationGuideController.class)
+class ApplicationGuideControllerTest extends ControllerTestSupport {
+
+    @Test
+    void 신청_가이드_목록_조회_시_200과_가이드_목록을_반환한다() {
+        Long performanceLocationId = 1L;
+
+        ApplicationGuideListResponse mockResponse = ApplicationGuideListResponse.builder()
+                .applicationGuideResponses(List.of(
+                        ApplicationGuideResponse.builder()
+                                .applicationGuideId(1L)
+                                .performanceLocationId(performanceLocationId)
+                                .content("사전 신청 필수")
+                                .build()
+                ))
+                .build();
+
+        given(applicationGuideService.getApplicationGuides(performanceLocationId))
+                .willReturn(mockResponse);
+
+        assertThat(mvcTester.get()
+                .uri("/performance-locations/{performanceLocationId}/application-guides", performanceLocationId))
+                .hasStatusOk()
+                .bodyJson()
+                .satisfies(json -> {
+                    assertThat(json).extractingPath("$.applicationGuideResponses[0].content")
+                            .asString().isEqualTo("사전 신청 필수");
+                    assertThat(json).extractingPath("$.applicationGuideResponses[0].performanceLocationId")
+                            .asNumber().isEqualTo(1);
+                });
+    }
+
+    @Test
+    void 신청_가이드가_없으면_빈_목록을_반환한다() {
+        Long performanceLocationId = 1L;
+
+        ApplicationGuideListResponse mockResponse = ApplicationGuideListResponse.builder()
+                .applicationGuideResponses(List.of())
+                .build();
+
+        given(applicationGuideService.getApplicationGuides(performanceLocationId))
+                .willReturn(mockResponse);
+
+        assertThat(mvcTester.get()
+                .uri("/performance-locations/{performanceLocationId}/application-guides", performanceLocationId))
+                .hasStatusOk()
+                .bodyJson()
+                .satisfies(json -> {
+                    assertThat(json).extractingPath("$.applicationGuideResponses").isEqualTo(List.of());
+                });
+    }
+
+}

--- a/src/test/java/team/unibusk/backend/global/support/ControllerTestSupport.java
+++ b/src/test/java/team/unibusk/backend/global/support/ControllerTestSupport.java
@@ -6,6 +6,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.assertj.MockMvcTester;
 import org.springframework.validation.beanvalidation.MethodValidationPostProcessor;
+import team.unibusk.backend.domain.applicationguide.application.ApplicationGuideService;
 import team.unibusk.backend.domain.member.application.MemberService;
 import team.unibusk.backend.domain.performance.application.PerformanceService;
 import team.unibusk.backend.domain.performanceLocation.application.PerformanceLocationService;
@@ -34,6 +35,9 @@ public abstract class ControllerTestSupport {
 
     @MockitoBean
     protected PerformanceLocationService performanceLocationService;
+
+    @MockitoBean
+    protected ApplicationGuideService applicationGuideService;
 
 }
 


### PR DESCRIPTION
## 관련 이슈
- #196

## Summary

`ApplicationGuide` 도메인의 서비스 및 컨트롤러 단위 테스트를 작성했습니다.

## Tasks

- `ApplicationGuideService` 단위 테스트 작성
- `ApplicationGuideController` 단위 테스트 작성


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
한 줄 요약: `ApplicationGuide` 도메인의 서비스와 컨트롤러 계층에 대한 단위 테스트를 추가하여 예외 경로와 정상/빈 결과 반환 흐름을 검증하도록 했습니다.

✨ 추가
- `ApplicationGuideServiceTest` 클래스
  - 무엇을: `@InjectMocks`로 `ApplicationGuideService`를 주입하고 `@Mock`으로 `ApplicationGuideRepository`, `PerformanceLocationRepository`를 목(mock)하여 아래 테스트 메서드들을 추가함: `신청_가이드_목록을_정상_조회한다()`, `신청_가이드가_없으면_빈_목록을_반환한다()`, `존재하지_않는_장소_ID로_조회하면_예외가_발생한다()`.
  - 이유 및 효과: 서비스의 정상 응답(다수/빈 리스트)과 예외 전파(`PerformanceLocationNotFoundException`) 동작을 단위 테스트로 검증하여 서비스 계층의 제어 흐름과 외부 저장소 호출 여부(`findById()`, `findAllByPerformanceLocationId()`)를 명확히 확인할 수 있게 함.
- `ApplicationGuideControllerTest` 클래스
  - 무엇을: `@WebMvcTest`로 `ApplicationGuideController`를 테스트하며 `ControllerTestSupport`를 상속해 MVC 요청을 수행하는 테스트 메서드 `신청_가이드_목록_조회_시_200과_가이드_목록을_반환한다()` 및 `신청_가이드가_없으면_빈_목록을_반환한다()` 추가.
  - 이유 및 효과: 컨트롤러 엔드포인트(`/performance-locations/{performanceLocationId}/application-guides`)에서 서비스 결과(응답 본문의 `applicationGuideResponses` 항목들)에 대해 HTTP 200과 JSON 필드(`content`, `performanceLocationId`) 반환을 검증하여 프레젠테이션 계층의 응답 규격을 보장함.
- `ControllerTestSupport`에 `applicationGuideService` 필드(`@MockitoBean`) 추가
  - 무엇을: 테스트 지원 클래스에 `@MockitoBean`으로 `ApplicationGuideService applicationGuideService`를 추가.
  - 이유 및 효과: 컨트롤러 테스트에서 공유되는 `ApplicationGuideService` 목을 중앙에서 제공하여 각 컨트롤러 테스트에서 목 설정을 일관되게 할 수 있도록 지원함.

🔧 변경
- 테스트 코드 내부에서 테스트 데이터 설정 목적(`PerformanceLocationFixture` 사용)과 엔티티 식별자 주입(`ReflectionTestUtils.setField`)을 사용해 테스트 상태를 구성하도록 구현함.
  - 이유 및 효과: 실제 엔티티 상태를 시뮬레이션하여 테스트가 엔티티 ID 기반 조회 로직과 일치하도록 구성함.

🗑️ 제거
- 없음

🐛 수정
- 없음

⚙️ 설정
- 없음
<!-- end of auto-generated comment: release notes by coderabbit.ai -->