### PR TITLE
Fix: blue-green 배포 중 OOM 방지를 위한 JVM 힙 메모리 제한 추가

### DIFF
--- a/deployment/prod/docker/docker-compose.yml
+++ b/deployment/prod/docker/docker-compose.yml
@@ -5,13 +5,19 @@ services:
     image: ${DOCKER_USERNAME}/${IMAGE_NAME}:${IMAGE_TAG}
     container_name: unibusk-blue
     stop_grace_period: 35s
+    deploy:
+      resources:
+        limits:
+          memory: 768m
+        reservations:
+          memory: 512m
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
       - SPRING_PROFILES_ACTIVE=prod
       - DB_HOST=host.docker.internal
       - REDIS_HOST=host.docker.internal
-      - JAVA_OPTS=-Xms256m -Xmx400m
+      - JAVA_OPTS=-Xms256m -Xmx400m -XX:MaxMetaspaceSize=128m -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -XX:+UseContainerSupport
     ports:
       - "8081:8080"
     env_file:
@@ -30,13 +36,19 @@ services:
     image: ${DOCKER_USERNAME}/${IMAGE_NAME}:${IMAGE_TAG}
     container_name: unibusk-green
     stop_grace_period: 35s
+    deploy:
+      resources:
+        limits:
+          memory: 768m
+        reservations:
+          memory: 512m
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
       - SPRING_PROFILES_ACTIVE=prod
       - DB_HOST=host.docker.internal
       - REDIS_HOST=host.docker.internal
-      - JAVA_OPTS=-Xms256m -Xmx400m
+      - JAVA_OPTS=-Xms256m -Xmx400m -XX:MaxMetaspaceSize=128m -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -XX:+UseContainerSupport
     ports:
       - "8082:8080"
     env_file:

--- a/deployment/prod/docker/docker-compose.yml
+++ b/deployment/prod/docker/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       - SPRING_PROFILES_ACTIVE=prod
       - DB_HOST=host.docker.internal
       - REDIS_HOST=host.docker.internal
+      - JAVA_OPTS=-Xms256m -Xmx400m
     ports:
       - "8081:8080"
     env_file:
@@ -35,6 +36,7 @@ services:
       - SPRING_PROFILES_ACTIVE=prod
       - DB_HOST=host.docker.internal
       - REDIS_HOST=host.docker.internal
+      - JAVA_OPTS=-Xms256m -Xmx400m
     ports:
       - "8082:8080"
     env_file:

--- a/deployment/prod/docker/docker-compose.yml
+++ b/deployment/prod/docker/docker-compose.yml
@@ -4,13 +4,9 @@ services:
   blue:
     image: ${DOCKER_USERNAME}/${IMAGE_NAME}:${IMAGE_TAG}
     container_name: unibusk-blue
+    mem_limit: 768m
+    mem_reservation: 512m
     stop_grace_period: 35s
-    deploy:
-      resources:
-        limits:
-          memory: 768m
-        reservations:
-          memory: 512m
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
@@ -35,13 +31,9 @@ services:
   green:
     image: ${DOCKER_USERNAME}/${IMAGE_NAME}:${IMAGE_TAG}
     container_name: unibusk-green
+    mem_limit: 768m
+    mem_reservation: 512m
     stop_grace_period: 35s
-    deploy:
-      resources:
-        limits:
-          memory: 768m
-        reservations:
-          memory: 512m
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:


### PR DESCRIPTION
## 관련 이슈
- #198

## Summary

blue-green 배포 시 두 컨테이너가 동시에 실행되는 구간에 메모리가 급증하여 헬스체크 실패 및 배포 오류가 발생하는 문제를 수정합니다.

## Tasks

- docker-compose.yml blue/green 서비스에 JVM 힙 메모리 제한 추가 (`-Xms256m -Xmx400m`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
한 줄 요약: `deployment/prod/docker/docker-compose.yml`의 `blue`/`green` 서비스에 JVM 힙(`-Xms256m -Xmx400m`)과 컨테이너 메모리 제한(`mem_limit`/`mem_reservation`)을 추가하여 블루-그린 배포 중 OOM 발생을 방지했습니다.

⚙️ 설정
- `deployment/prod/docker/docker-compose.yml`의 `blue`, `green` 서비스에 `JAVA_OPTS` 환경변수 추가 (`-Xms256m -Xmx400m -XX:MaxMetaspaceSize=128m -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -XX:+UseContainerSupport`)
  - 변경 이유: 두 컨테이너가 동시에 실행될 때 JVM이 자동으로 큰 힙을 할당해 메모리 사용이 급증하고 헬스체크가 실패했기 때문에 JVM 힙 크기와 GC/메타스페이스 동작을 명시적으로 제한하기 위함입니다.
  - 효과: JVM 힙을 최소 256MB, 최대 400MB로 고정하고 메타스페이스/GC 설정을 적용하여 JVM 수준의 메모리 사용량 급증 가능성을 줄입니다.
- `deployment/prod/docker/docker-compose.yml`의 `blue`, `green` 서비스에 `mem_limit: 768m` 및 `mem_reservation: 512m` 추가 (`mem_limit`/`mem_reservation` 사용)
  - 변경 이유: 이전에 사용하던 `deploy.resources`가 실제로 컨테이너 메모리 제한을 적용하지 못하는 환경 이슈를 해결하기 위해 Docker Compose에서 동작하는 `mem_limit`/`mem_reservation`로 변경했습니다.
  - 효과: 컨테이너 레벨에서 메모리 상한(768MB)과 예약(512MB)을 명시하여 호스트 메모리 경쟁을 완화하고 블루-그린 전환 시 두 인스턴스가 동시에 호스트 메모리를 초과하는 것을 방지합니다.

🔧 변경
- `deployment/prod/docker/docker-compose.yml`의 `blue`/`green` 서비스 `environment`에 기존 환경 변수(`SPRING_PROFILES_ACTIVE`, `DB_HOST`, `REDIS_HOST` 등)는 유지된 채 `JAVA_OPTS`가 추가됨
  - 변경 이유: 기존 서비스 설정을 그대로 유지하면서 JVM 동작만 제어하기 위함입니다.
  - 효과: 기존 설정과의 호환성 유지 및 JVM 메모리/GC 제어 적용.

🐛 수정
- 블루-그린 배포 중 발생하던 OOM 및 헬스체크 실패 문제 수정
  - 변경 이유: 배포 과정에서 두 인스턴스 동시 실행으로 메모리 사용이 급증해 헬스체크 실패와 배포 오류가 발생했음.
  - 효과: JVM 힙 제한과 컨테이너 메모리 제한으로 메모리 스파이크를 억제해 배포 안정성이 향상됩니다.

🗑️ 제거
- 없음 (삭제된 클래스/메서드 없음)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->