### PR TITLE
Infra: EC2 기동 시간에 맞춘 배포 자동화 스케줄 추가

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -7,6 +7,10 @@ on:
     - cron: '10 0 * * *'
   workflow_dispatch:
 
+concurrency:
+  group: deploy-prod
+  cancel-in-progress: false
+
 permissions:
   contents: read
 

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -3,6 +3,9 @@ name: Blue-Green Deploy PROD
 on:
   push:
     branches: [ "main" ]
+  schedule:
+    - cron: '10 0 * * *'
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
## 관련 이슈
- #200

## Summary

EC2 운영 시간(09:00~21:00) 외에 main 브랜치에 push 시 배포가 실패하는 문제를 해결합니다.
매일 09:10 KST에 자동으로 배포를 재시도하여 오프타임에 작업한 내용이 서버 기동 후 자동 반영됩니다.

## Tasks

- cicd.yml에 schedule 트리거 추가 (매일 09:10 KST 자동 배포)
- cicd.yml에 workflow_dispatch 트리거 추가 (수동 배포 가능)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
EC2 운영 시간(09:00~21:00) 외에 main 브랜치에 푸시된 변경사항이 서버 기동 후 자동으로 반영되도록 GitHub Actions 워크플로우에 스케줄 및 수동 배포 트리거와 동시 실행 제어를 추가했습니다.

🗑️ 제거
- 없음

✨ 추가
- `.github/workflows/cicd.yml`에 `schedule` 트리거 추가: 매일 09:10 KST(`cron: '10 0 * * *'`)에 워크플로우를 자동 실행하도록 설정했습니다 — 이유: 야간(오프타임)에 main에 푸시된 변경사항이 EC2가 기동된 이후에도 자동으로 배포되도록 하기 위함. 효과: 오프타임에 수행된 커밋이 서버 기동 후 자동 반영되어 수동 재배포 없이도 배포 누락 문제를 방지합니다.
- `.github/workflows/cicd.yml`에 `workflow_dispatch` 트리거 추가: GitHub UI에서 수동으로 배포를 실행할 수 있게 활성화했습니다 — 이유: 즉시 재배포나 수동 테스트가 필요할 때 사용하기 위함. 효과: 필요시 개발자가 즉시 워크플로우를 트리거할 수 있어 재시도 유연성이 증가합니다.
- 커밋 메시지로 추가된 내용: `Fix: 배포 워크플로우 동시 실행 방지를 위한 concurrency 설정 추가` — 이유: 동일 워크플로우의 중복 실행으로 인한 충돌을 방지하기 위함. 효과: 불필요한 동시 배포 시도가 줄어들어 배포 충돌 가능성이 낮아집니다.

🔧 변경
- `.github/workflows/cicd.yml`의 트리거 목록에 기존 `push`(`branches: [ main ]`)는 유지하면서 `schedule` 및 `workflow_dispatch`를 병행하도록 변경했습니다 — 이유: 기존 푸시 기반 배포는 유지하되, 오프타임 문제 해결 및 수동 실행을 가능하게 하기 위함. 효과: 기존 워크플로우 동작을 보존하면서 자동/수동 재시도 경로를 추가합니다.
- `.github/workflows/cicd.yml`에 `concurrency` 설정 추가 (`group: 'deploy-prod'`, `cancel-in-progress: false`) — 이유: 동일 그룹 내 동시 실행 관리를 위해. 효과: 새로운 실행이 기존 실행을 취소하지 않고 그룹화하여 실행 상태를 명확히 관리합니다.

🐛 수정
- 없음
<!-- end of auto-generated comment: release notes by coderabbit.ai -->