### PR TITLE
Fix: 메모리 부족으로 인한 스케줄 배포 비활성화

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -3,13 +3,6 @@ name: Blue-Green Deploy PROD
 on:
   push:
     branches: [ "main" ]
-  schedule:
-    - cron: '10 0 * * *'
-  workflow_dispatch:
-
-concurrency:
-  group: deploy-prod
-  cancel-in-progress: false
 
 permissions:
   contents: read


### PR DESCRIPTION
## 관련 이슈
- #203

## Summary
t3.small 메모리 부족으로 스케줄 배포 시 blue/green 동시 기동으로 OOM 발생
push 트리거만 남기고 스케줄 배포 비활성화

## Tasks
- 스케줄 배포(cron) 제거
- workflow_dispatch 제거
- concurrency 설정 제거

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 스케줄 배포 비활성화를 위해 CI/CD 워크플로우 트리거 및 동시성 설정 제거

### ⚙️ 설정

#### `.github/workflows/cicd.yml` - 워크플로우 트리거 및 동시성 설정 제거
- **변경 내용**: 
  - `schedule` 트리거 제거 (cron: `'10 0 * * *'`)
  - `workflow_dispatch` 트리거 제거 (수동 배포 트리거)
  - workflow-level `concurrency` 설정 제거 (`group: deploy-prod`, `cancel-in-progress: false`)
  
- **변경 이유**: t3.small 인스턴스의 제한된 메모리에서 스케줄 배포 실행 시 Blue/Green 배포로 인한 두 버전의 동시 기동으로 OOM(Out of Memory) 발생 방지

- **효과**: 이제 워크플로우는 main 브랜치로의 push 이벤트에만 반응하여 자동 배포되며, 메모리 부족으로 인한 배포 실패 방지

<!-- end of auto-generated comment: release notes by coderabbit.ai -->