### PR TITLE
Refactor: Docker 베이스 이미지 alpine 전환으로 이미지 크기 최적화

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,13 @@
-FROM eclipse-temurin:17-jre
-ENV TZ=Asia/Seoul
+FROM eclipse-temurin:17-jre-alpine
 ARG JAR_FILE=build/libs/*.jar
 
-RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
+RUN apk add --no-cache curl tzdata && \
+    cp /usr/share/zoneinfo/Asia/Seoul /etc/localtime && \
+    echo "Asia/Seoul" > /etc/timezone
 
-RUN addgroup --system spring && adduser --system --group spring
+ENV TZ=Asia/Seoul
+
+RUN addgroup -S spring && adduser -S spring -G spring
 USER spring:spring
 
 COPY --chown=spring:spring ${JAR_FILE} app.jar


### PR DESCRIPTION
## 관련 이슈
- #205

## Summary

베이스 이미지를 eclipse-temurin:17-jre-alpine으로 전환하여 Docker 이미지 크기를 최적화합니다.
또한 alpine 환경에서 타임존이 올바르게 적용되도록 tzdata 설치 및 설정을 추가합니다.

## Tasks

- 베이스 이미지 eclipse-temurin:17-jre → eclipse-temurin:17-jre-alpine 변경
- 패키지 매니저 apt-get → apk 전환 및 tzdata 설치
- /etc/localtime 심볼릭 링크 설정으로 alpine 타임존 적용


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Docker 베이스 이미지를 Alpine 기반으로 전환하여 이미지 크기를 최적화하고 경량 환경에 맞는 설정으로 변경하였습니다.

## ⚙️ 설정

**베이스 이미지 변경: `eclipse-temurin:17-jre` → `eclipse-temurin:17-jre-alpine`**
- 변경 이유: Alpine Linux는 Debian 기반보다 훨씬 작은 크기로, 컨테이너 이미지 용량을 대폭 감소시킬 수 있음
- 효과: Docker 이미지 크기 최적화로 배포 속도 향상 및 스토리지 비용 절감

**패키지 매니저 변경: `apt-get` → `apk`**
- 변경 이유: Alpine Linux는 apt-get 대신 apk를 패키지 매니저로 사용함
- 효과: Alpine 환경에서 패키지 설치가 정상적으로 작동

**패키지 설치 추가: `apk add --no-cache curl tzdata`**
- 변경 이유: 헬스체크에 필요한 `curl`과 타임존 설정에 필요한 `tzdata` 패키지 명시적 설치
- 효과: HEALTHCHECK 엔드포인트 동작 및 타임존 정보 지원 확보

**타임존 설정 명시화**
- 변경 이유: Alpine 환경에서는 `/etc/localtime` 심볼릭 링크와 `/etc/timezone` 파일을 명시적으로 설정해야 타임존이 적용됨
- 효과: `Asia/Seoul` 타임존이 정확하게 애플리케이션에 반영되어 로그 및 시간 관련 기능의 정확성 보장

**사용자 생성 명령 변경: `addgroup --system`/`adduser --system --group` → `addgroup -S`/`adduser -S`**
- 변경 이유: Alpine Linux는 Debian 계열의 옵션을 지원하지 않으므로 Alpine 형식의 단축 옵션 사용 필요
- 효과: Alpine 환경에서 spring 사용자 및 그룹이 정상적으로 생성되어 보안 설정이 제대로 작동

<!-- end of auto-generated comment: release notes by coderabbit.ai -->