### PR TITLE
Fix: Metaspace OOM 방지를 위해 MaxMetaspaceSize 128m → 256m 증가

### DIFF
--- a/deployment/prod/docker/docker-compose.yml
+++ b/deployment/prod/docker/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - SPRING_PROFILES_ACTIVE=prod
       - DB_HOST=host.docker.internal
       - REDIS_HOST=host.docker.internal
-      - JAVA_OPTS=-Xms256m -Xmx400m -XX:MaxMetaspaceSize=256m -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -XX:+UseContainerSupport
+      - JAVA_OPTS=-Xms256m -Xmx350m -XX:MaxMetaspaceSize=256m -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -XX:+UseContainerSupport
     ports:
       - "8081:8080"
     env_file:
@@ -40,7 +40,7 @@ services:
       - SPRING_PROFILES_ACTIVE=prod
       - DB_HOST=host.docker.internal
       - REDIS_HOST=host.docker.internal
-      - JAVA_OPTS=-Xms256m -Xmx400m -XX:MaxMetaspaceSize=256m -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -XX:+UseContainerSupport
+      - JAVA_OPTS=-Xms256m -Xmx350m -XX:MaxMetaspaceSize=256m -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -XX:+UseContainerSupport
     ports:
       - "8082:8080"
     env_file:

--- a/deployment/prod/docker/docker-compose.yml
+++ b/deployment/prod/docker/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - SPRING_PROFILES_ACTIVE=prod
       - DB_HOST=host.docker.internal
       - REDIS_HOST=host.docker.internal
-      - JAVA_OPTS=-Xms256m -Xmx400m -XX:MaxMetaspaceSize=128m -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -XX:+UseContainerSupport
+      - JAVA_OPTS=-Xms256m -Xmx400m -XX:MaxMetaspaceSize=256m -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -XX:+UseContainerSupport
     ports:
       - "8081:8080"
     env_file:
@@ -40,7 +40,7 @@ services:
       - SPRING_PROFILES_ACTIVE=prod
       - DB_HOST=host.docker.internal
       - REDIS_HOST=host.docker.internal
-      - JAVA_OPTS=-Xms256m -Xmx400m -XX:MaxMetaspaceSize=128m -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -XX:+UseContainerSupport
+      - JAVA_OPTS=-Xms256m -Xmx400m -XX:MaxMetaspaceSize=256m -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -XX:+UseContainerSupport
     ports:
       - "8082:8080"
     env_file:


### PR DESCRIPTION
## 관련 이슈
- #208

## Summary
OutOfMemoryError: Metaspace 반복 발생으로 요청 처리 실패
MaxMetaspaceSize를 128m에서 256m으로 증가하여 Metaspace OOM 방지

## Tasks
- docker-compose-blue.yml MaxMetaspaceSize 128m → 256m 변경
- docker-compose-green.yml MaxMetaspaceSize 128m → 256m 변경

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
한 줄 요약: `docker-compose-blue.yml` 및 `docker-compose-green.yml`의 `JAVA_OPTS` 값을 조정하여 Metaspace OOM 및 OOMKill 발생을 방지함.

⚙️ 설정
- 변경 파일: `deployment/prod/docker/docker-compose-blue.yml`, `deployment/prod/docker/docker-compose-green.yml`
- 무엇을 변경했는가:
  - `JAVA_OPTS`의 `-XX:MaxMetaspaceSize=128m` → `-XX:MaxMetaspaceSize=256m`
- 변경 이유 및 효과:
  - 이유: 반복적으로 발생한 `OutOfMemoryError: Metaspace`로 인해 요청 처리 실패가 발생했기 때문에 Metaspace 한도를 상향 조정함.
  - 효과: Metaspace 할당량이 증가하여 Metaspace 부족으로 인한 JVM 예외 발생 가능성을 낮춰 해당 오류로 인한 요청 실패가 감소함.

🔧 변경
- 무엇을 변경했는가:
  - `JAVA_OPTS`의 `-Xmx400m` → `-Xmx350m` (한 커밋에서 추가 조정)
- 변경 이유 및 효과:
  - 이유: 컨테이너 수준에서 프로세스 전체 메모리 제한으로 인한 `OOMKill` 발생을 줄이기 위해 최대 힙 크기를 소폭 하향 조정함.
  - 효과: JVM 힙 최대값 감소로 컨테이너 메모리 총 사용량이 줄어들어 호스트/컨테이너의 OOMKill 발생 가능성이 낮아짐.

🐛 수정
- 무엇을 수정했는가:
  - Metaspace 설정 및 힙 설정의 값 변경으로 Metaspace OOM 및 컨테이너 OOMKill에 대응함.
- 변경 이유 및 효과:
  - 이유: 실제 운영에서 관찰된 `OutOfMemoryError: Metaspace` 및 OOMKill 원인 대응.
  - 효과: Metaspace 관련 예외로 인한 서비스 오류 빈도 감소 및 컨테이너 수준의 OOMKill 위험 감소.

(삭제된 클래스/메서드 없음)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->