### PR TITLE
Refactor: Member 도메인 CQS 패턴 적용

### DIFF
--- a/src/main/java/team/unibusk/backend/domain/member/application/command/MemberCommandService.java
+++ b/src/main/java/team/unibusk/backend/domain/member/application/command/MemberCommandService.java
@@ -1,24 +1,22 @@
-package team.unibusk.backend.domain.member.application;
+package team.unibusk.backend.domain.member.application.command;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import team.unibusk.backend.domain.member.application.dto.request.MemberNameUpdateServiceRequest;
-import team.unibusk.backend.domain.member.application.dto.response.MemberInfoResponse;
 import team.unibusk.backend.domain.member.application.dto.response.MemberNameUpdateResponse;
 import team.unibusk.backend.domain.member.domain.Member;
 import team.unibusk.backend.domain.member.domain.MemberRepository;
 
 @RequiredArgsConstructor
 @Service
-public class MemberService {
+public class MemberCommandService {
 
     private final MemberRepository memberRepository;
 
     @Transactional
     public MemberNameUpdateResponse updateMemberName(MemberNameUpdateServiceRequest request) {
         Member member = memberRepository.findByMemberId(request.memberId());
-
         member.updateName(request.name());
 
         return MemberNameUpdateResponse.builder()
@@ -26,13 +24,6 @@ public class MemberService {
                 .email(member.getEmail())
                 .name(member.getName())
                 .build();
-    }
-
-    @Transactional(readOnly = true)
-    public MemberInfoResponse getMyInfo(Long memberId) {
-        Member member = memberRepository.findByMemberId(memberId);
-
-        return MemberInfoResponse.from(member);
     }
 
 }

--- a/src/main/java/team/unibusk/backend/domain/member/application/query/MemberQueryService.java
+++ b/src/main/java/team/unibusk/backend/domain/member/application/query/MemberQueryService.java
@@ -1,0 +1,23 @@
+package team.unibusk.backend.domain.member.application.query;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import team.unibusk.backend.domain.member.application.dto.response.MemberInfoResponse;
+import team.unibusk.backend.domain.member.domain.Member;
+import team.unibusk.backend.domain.member.domain.MemberRepository;
+
+@RequiredArgsConstructor
+@Service
+public class MemberQueryService {
+
+    private final MemberRepository memberRepository;
+
+    @Transactional(readOnly = true)
+    public MemberInfoResponse getMyInfo(Long memberId) {
+        Member member = memberRepository.findByMemberId(memberId);
+
+        return MemberInfoResponse.from(member);
+    }
+
+}

--- a/src/main/java/team/unibusk/backend/domain/member/presentation/command/MemberCommandController.java
+++ b/src/main/java/team/unibusk/backend/domain/member/presentation/command/MemberCommandController.java
@@ -1,35 +1,28 @@
-package team.unibusk.backend.domain.member.presentation;
+package team.unibusk.backend.domain.member.presentation.command;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import team.unibusk.backend.domain.member.application.MemberService;
-import team.unibusk.backend.domain.member.application.dto.response.MemberInfoResponse;
+import team.unibusk.backend.domain.member.application.command.MemberCommandService;
 import team.unibusk.backend.domain.member.application.dto.response.MemberNameUpdateResponse;
+import team.unibusk.backend.domain.member.presentation.MemberCommandDocsController;
 import team.unibusk.backend.domain.member.presentation.request.MemberNameUpdateRequest;
 import team.unibusk.backend.global.annotation.MemberId;
 
 @RequiredArgsConstructor
 @RequestMapping("/members")
 @RestController
-public class MemberController implements MemberDocsController {
+public class MemberCommandController implements MemberCommandDocsController {
 
-    private final MemberService memberService;
+    private final MemberCommandService memberCommandService;
 
     @PatchMapping("/me")
     public ResponseEntity<MemberNameUpdateResponse> updateMemberName(
             @MemberId Long memberId,
             @Valid @RequestBody MemberNameUpdateRequest request
     ) {
-        MemberNameUpdateResponse response = memberService.updateMemberName(request.toServiceRequest(memberId));
-
-        return ResponseEntity.status(200).body(response);
-    }
-
-    @GetMapping("/me")
-    public ResponseEntity<MemberInfoResponse> getMyInfo(@MemberId Long memberId) {
-        MemberInfoResponse response = memberService.getMyInfo(memberId);
+        MemberNameUpdateResponse response = memberCommandService.updateMemberName(request.toServiceRequest(memberId));
 
         return ResponseEntity.status(200).body(response);
     }

--- a/src/main/java/team/unibusk/backend/domain/member/presentation/command/MemberCommandDocsController.java
+++ b/src/main/java/team/unibusk/backend/domain/member/presentation/command/MemberCommandDocsController.java
@@ -1,0 +1,37 @@
+package team.unibusk.backend.domain.member.presentation;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import team.unibusk.backend.domain.member.application.dto.response.MemberNameUpdateResponse;
+import team.unibusk.backend.domain.member.presentation.request.MemberNameUpdateRequest;
+import team.unibusk.backend.global.annotation.MemberId;
+import team.unibusk.backend.global.exception.ExceptionResponse;
+
+@Tag(name = "Member", description = "회원 관련 API")
+@RequestMapping("/members")
+public interface MemberCommandDocsController {
+
+    @Operation(summary = "회원 이름 변경", description = "로그인된 회원의 이름을 변경합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "이름 변경 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청",
+                    content = @Content(schema = @Schema(implementation = ExceptionResponse.class))),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자",
+                    content = @Content(schema = @Schema(implementation = ExceptionResponse.class)))
+    })
+    @PatchMapping("/me")
+    ResponseEntity<MemberNameUpdateResponse> updateMemberName(
+            @MemberId Long memberId,
+            @Valid @RequestBody MemberNameUpdateRequest request
+    );
+
+}

--- a/src/main/java/team/unibusk/backend/domain/member/presentation/query/MemberQueryController.java
+++ b/src/main/java/team/unibusk/backend/domain/member/presentation/query/MemberQueryController.java
@@ -1,0 +1,25 @@
+package team.unibusk.backend.domain.member.presentation.query;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import team.unibusk.backend.domain.member.application.dto.response.MemberInfoResponse;
+import team.unibusk.backend.domain.member.application.query.MemberQueryService;
+import team.unibusk.backend.domain.member.presentation.MemberQueryDocsController;
+import team.unibusk.backend.global.annotation.MemberId;
+
+@RequiredArgsConstructor
+@RequestMapping("/members")
+@RestController
+public class MemberQueryController implements MemberQueryDocsController {
+
+    private final MemberQueryService memberQueryService;
+
+    @GetMapping("/me")
+    public ResponseEntity<MemberInfoResponse> getMyInfo(@MemberId Long memberId) {
+        MemberInfoResponse response = memberQueryService.getMyInfo(memberId);
+
+        return ResponseEntity.status(200).body(response);
+    }
+
+}

--- a/src/main/java/team/unibusk/backend/domain/member/presentation/query/MemberQueryController.java
+++ b/src/main/java/team/unibusk/backend/domain/member/presentation/query/MemberQueryController.java
@@ -5,7 +5,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import team.unibusk.backend.domain.member.application.dto.response.MemberInfoResponse;
 import team.unibusk.backend.domain.member.application.query.MemberQueryService;
-import team.unibusk.backend.domain.member.presentation.MemberQueryDocsController;
 import team.unibusk.backend.global.annotation.MemberId;
 
 @RequiredArgsConstructor

--- a/src/main/java/team/unibusk/backend/domain/member/presentation/query/MemberQueryDocsController.java
+++ b/src/main/java/team/unibusk/backend/domain/member/presentation/query/MemberQueryDocsController.java
@@ -6,35 +6,16 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import team.unibusk.backend.domain.member.application.dto.response.MemberInfoResponse;
-import team.unibusk.backend.domain.member.application.dto.response.MemberNameUpdateResponse;
-import team.unibusk.backend.domain.member.presentation.request.MemberNameUpdateRequest;
 import team.unibusk.backend.global.annotation.MemberId;
 import team.unibusk.backend.global.exception.ExceptionResponse;
 
 @Tag(name = "Member", description = "회원 관련 API")
 @RequestMapping("/members")
-public interface MemberDocsController {
-
-    @Operation(summary = "회원 이름 변경", description = "로그인된 회원의 이름을 변경합니다.")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "이름 변경 성공"),
-            @ApiResponse(responseCode = "400", description = "잘못된 요청",
-                    content = @Content(schema = @Schema(implementation = ExceptionResponse.class))),
-            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자",
-                    content = @Content(schema = @Schema(implementation = ExceptionResponse.class)))
-    })
-    @PatchMapping("/me")
-    ResponseEntity<MemberNameUpdateResponse> updateMemberName(
-            @MemberId Long memberId,
-            @Valid @RequestBody MemberNameUpdateRequest request
-    );
+public interface MemberQueryDocsController {
 
     @Operation(summary = "내 정보 조회", description = "로그인된 회원의 정보를 조회합니다.")
     @ApiResponses({
@@ -43,8 +24,6 @@ public interface MemberDocsController {
                     content = @Content(schema = @Schema(implementation = ExceptionResponse.class)))
     })
     @GetMapping("/me")
-    ResponseEntity<MemberInfoResponse> getMyInfo(
-            @MemberId Long memberId
-    );
+    ResponseEntity<MemberInfoResponse> getMyInfo(@MemberId Long memberId);
 
 }

--- a/src/main/java/team/unibusk/backend/domain/member/presentation/query/MemberQueryDocsController.java
+++ b/src/main/java/team/unibusk/backend/domain/member/presentation/query/MemberQueryDocsController.java
@@ -1,4 +1,4 @@
-package team.unibusk.backend.domain.member.presentation;
+package team.unibusk.backend.domain.member.presentation.query;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;

--- a/src/test/java/team/unibusk/backend/domain/member/application/command/MemberCommandServiceTest.java
+++ b/src/test/java/team/unibusk/backend/domain/member/application/command/MemberCommandServiceTest.java
@@ -7,9 +7,11 @@ import team.unibusk.backend.domain.member.application.dto.request.MemberNameUpda
 import team.unibusk.backend.domain.member.application.dto.response.MemberNameUpdateResponse;
 import team.unibusk.backend.domain.member.domain.Member;
 import team.unibusk.backend.domain.member.domain.MemberRepository;
+import team.unibusk.backend.domain.member.presentation.exception.MemberNotFoundException;
 import team.unibusk.backend.global.support.UnitTestSupport;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 
 class MemberCommandServiceTest extends UnitTestSupport {
@@ -36,6 +38,15 @@ class MemberCommandServiceTest extends UnitTestSupport {
         assertThat(response.memberId()).isEqualTo(1L);
         assertThat(response.email()).isEqualTo("test@email.com");
         assertThat(response.name()).isEqualTo("김철수");
+    }
+
+    @Test
+    void 존재하지_않는_회원_이름_수정_시_MemberNotFoundException이_발생한다() {
+        given(memberRepository.findByMemberId(1L)).willThrow(new MemberNotFoundException());
+
+        assertThatThrownBy(() -> memberCommandService.updateMemberName(
+                new MemberNameUpdateServiceRequest(1L, "김철수")
+        )).isInstanceOf(MemberNotFoundException.class);
     }
 
 }

--- a/src/test/java/team/unibusk/backend/domain/member/application/command/MemberCommandServiceTest.java
+++ b/src/test/java/team/unibusk/backend/domain/member/application/command/MemberCommandServiceTest.java
@@ -1,10 +1,9 @@
-package team.unibusk.backend.domain.member.application;
+package team.unibusk.backend.domain.member.application.command;
 
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import team.unibusk.backend.domain.member.application.dto.request.MemberNameUpdateServiceRequest;
-import team.unibusk.backend.domain.member.application.dto.response.MemberInfoResponse;
 import team.unibusk.backend.domain.member.application.dto.response.MemberNameUpdateResponse;
 import team.unibusk.backend.domain.member.domain.Member;
 import team.unibusk.backend.domain.member.domain.MemberRepository;
@@ -13,10 +12,10 @@ import team.unibusk.backend.global.support.UnitTestSupport;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 
-class MemberServiceTest extends UnitTestSupport {
+class MemberCommandServiceTest extends UnitTestSupport {
 
     @InjectMocks
-    private MemberService memberService;
+    private MemberCommandService memberCommandService;
 
     @Mock
     private MemberRepository memberRepository;
@@ -30,29 +29,13 @@ class MemberServiceTest extends UnitTestSupport {
                 .build();
         given(memberRepository.findByMemberId(1L)).willReturn(member);
 
-        MemberNameUpdateResponse response = memberService.updateMemberName(
+        MemberNameUpdateResponse response = memberCommandService.updateMemberName(
                 new MemberNameUpdateServiceRequest(1L, "김철수")
         );
 
         assertThat(response.memberId()).isEqualTo(1L);
         assertThat(response.email()).isEqualTo("test@email.com");
         assertThat(response.name()).isEqualTo("김철수");
-    }
-
-    @Test
-    void 내_정보를_조회하면_회원_정보가_반환된다() {
-        Member member = Member.builder()
-                .id(1L)
-                .email("test@email.com")
-                .name("홍길동")
-                .build();
-        given(memberRepository.findByMemberId(1L)).willReturn(member);
-
-        MemberInfoResponse response = memberService.getMyInfo(1L);
-
-        assertThat(response.memberId()).isEqualTo(1L);
-        assertThat(response.email()).isEqualTo("test@email.com");
-        assertThat(response.name()).isEqualTo("홍길동");
     }
 
 }

--- a/src/test/java/team/unibusk/backend/domain/member/application/query/MemberQueryServiceTest.java
+++ b/src/test/java/team/unibusk/backend/domain/member/application/query/MemberQueryServiceTest.java
@@ -6,9 +6,11 @@ import org.mockito.Mock;
 import team.unibusk.backend.domain.member.application.dto.response.MemberInfoResponse;
 import team.unibusk.backend.domain.member.domain.Member;
 import team.unibusk.backend.domain.member.domain.MemberRepository;
+import team.unibusk.backend.domain.member.presentation.exception.MemberNotFoundException;
 import team.unibusk.backend.global.support.UnitTestSupport;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 
 class MemberQueryServiceTest extends UnitTestSupport {
@@ -33,6 +35,14 @@ class MemberQueryServiceTest extends UnitTestSupport {
         assertThat(response.memberId()).isEqualTo(1L);
         assertThat(response.email()).isEqualTo("test@email.com");
         assertThat(response.name()).isEqualTo("홍길동");
+    }
+
+    @Test
+    void 존재하지_않는_회원_조회_시_MemberNotFoundException이_발생한다() {
+        given(memberRepository.findByMemberId(1L)).willThrow(new MemberNotFoundException());
+
+        assertThatThrownBy(() -> memberQueryService.getMyInfo(1L))
+                .isInstanceOf(MemberNotFoundException.class);
     }
 
 }

--- a/src/test/java/team/unibusk/backend/domain/member/application/query/MemberQueryServiceTest.java
+++ b/src/test/java/team/unibusk/backend/domain/member/application/query/MemberQueryServiceTest.java
@@ -1,0 +1,38 @@
+package team.unibusk.backend.domain.member.application.query;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import team.unibusk.backend.domain.member.application.dto.response.MemberInfoResponse;
+import team.unibusk.backend.domain.member.domain.Member;
+import team.unibusk.backend.domain.member.domain.MemberRepository;
+import team.unibusk.backend.global.support.UnitTestSupport;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+class MemberQueryServiceTest extends UnitTestSupport {
+
+    @InjectMocks
+    private MemberQueryService memberQueryService;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Test
+    void 내_정보를_조회하면_회원_정보가_반환된다() {
+        Member member = Member.builder()
+                .id(1L)
+                .email("test@email.com")
+                .name("홍길동")
+                .build();
+        given(memberRepository.findByMemberId(1L)).willReturn(member);
+
+        MemberInfoResponse response = memberQueryService.getMyInfo(1L);
+
+        assertThat(response.memberId()).isEqualTo(1L);
+        assertThat(response.email()).isEqualTo("test@email.com");
+        assertThat(response.name()).isEqualTo("홍길동");
+    }
+
+}

--- a/src/test/java/team/unibusk/backend/domain/member/presentation/command/MemberCommandControllerTest.java
+++ b/src/test/java/team/unibusk/backend/domain/member/presentation/command/MemberCommandControllerTest.java
@@ -1,10 +1,9 @@
-package team.unibusk.backend.domain.member.presentation;
+package team.unibusk.backend.domain.member.presentation.command;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import team.unibusk.backend.domain.member.application.dto.response.MemberInfoResponse;
 import team.unibusk.backend.domain.member.application.dto.response.MemberNameUpdateResponse;
 import team.unibusk.backend.domain.member.presentation.request.MemberNameUpdateRequest;
 import team.unibusk.backend.global.support.ControllerTestSupport;
@@ -15,29 +14,8 @@ import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verifyNoInteractions;
 
-@WebMvcTest(controllers = {MemberController.class})
-class MemberControllerTest extends ControllerTestSupport {
-
-    @Test
-    @TestMember
-    void 내_정보_조회_시_200과_회원_정보가_반환된다() {
-        MemberInfoResponse response = MemberInfoResponse.builder()
-                .memberId(1L)
-                .email("test@email.com")
-                .name("홍길동")
-                .build();
-        given(memberService.getMyInfo(1L)).willReturn(response);
-
-        assertThat(mvcTester.get().uri("/members/me"))
-                .hasStatusOk()
-                .bodyJson()
-                .convertTo(MemberInfoResponse.class)
-                .satisfies(res -> {
-                    assertThat(res.memberId()).isEqualTo(1L);
-                    assertThat(res.email()).isEqualTo("test@email.com");
-                    assertThat(res.name()).isEqualTo("홍길동");
-                });
-    }
+@WebMvcTest(controllers = {MemberCommandController.class})
+class MemberCommandControllerTest extends ControllerTestSupport {
 
     @Test
     @TestMember
@@ -47,7 +25,7 @@ class MemberControllerTest extends ControllerTestSupport {
                 .email("test@email.com")
                 .name("김철수")
                 .build();
-        given(memberService.updateMemberName(
+        given(memberCommandService.updateMemberName(
                 argThat(req -> req.memberId().equals(1L) && req.name().equals("김철수"))
         )).willReturn(response);
 
@@ -76,7 +54,7 @@ class MemberControllerTest extends ControllerTestSupport {
                 .content(body))
                 .hasStatus(HttpStatus.BAD_REQUEST);
 
-        verifyNoInteractions(memberService);
+        verifyNoInteractions(memberCommandService);
     }
 
     @Test
@@ -89,7 +67,7 @@ class MemberControllerTest extends ControllerTestSupport {
                 .content(body))
                 .hasStatus(HttpStatus.BAD_REQUEST);
 
-        verifyNoInteractions(memberService);
+        verifyNoInteractions(memberCommandService);
     }
 
 }

--- a/src/test/java/team/unibusk/backend/domain/member/presentation/query/MemberQueryControllerTest.java
+++ b/src/test/java/team/unibusk/backend/domain/member/presentation/query/MemberQueryControllerTest.java
@@ -1,0 +1,36 @@
+package team.unibusk.backend.domain.member.presentation.query;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import team.unibusk.backend.domain.member.application.dto.response.MemberInfoResponse;
+import team.unibusk.backend.global.support.ControllerTestSupport;
+import team.unibusk.backend.global.support.TestMember;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+@WebMvcTest(controllers = {MemberQueryController.class})
+class MemberQueryControllerTest extends ControllerTestSupport {
+
+    @Test
+    @TestMember
+    void 내_정보_조회_시_200과_회원_정보가_반환된다() {
+        MemberInfoResponse response = MemberInfoResponse.builder()
+                .memberId(1L)
+                .email("test@email.com")
+                .name("홍길동")
+                .build();
+        given(memberQueryService.getMyInfo(1L)).willReturn(response);
+
+        assertThat(mvcTester.get().uri("/members/me"))
+                .hasStatusOk()
+                .bodyJson()
+                .convertTo(MemberInfoResponse.class)
+                .satisfies(res -> {
+                    assertThat(res.memberId()).isEqualTo(1L);
+                    assertThat(res.email()).isEqualTo("test@email.com");
+                    assertThat(res.name()).isEqualTo("홍길동");
+                });
+    }
+
+}

--- a/src/test/java/team/unibusk/backend/global/support/ControllerTestSupport.java
+++ b/src/test/java/team/unibusk/backend/global/support/ControllerTestSupport.java
@@ -7,6 +7,8 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.assertj.MockMvcTester;
 import org.springframework.validation.beanvalidation.MethodValidationPostProcessor;
 import team.unibusk.backend.domain.applicationguide.application.ApplicationGuideService;
+import team.unibusk.backend.domain.member.application.command.MemberCommandService;
+import team.unibusk.backend.domain.member.application.query.MemberQueryService;
 import team.unibusk.backend.domain.performance.application.PerformanceService;
 import team.unibusk.backend.domain.performanceLocation.application.PerformanceLocationService;
 import team.unibusk.backend.global.auth.application.auth.AuthService;
@@ -27,7 +29,10 @@ public abstract class ControllerTestSupport {
     protected AuthService authService;
 
     @MockitoBean
-    protected MemberService memberService;
+    protected MemberCommandService memberCommandService;
+
+    @MockitoBean
+    protected MemberQueryService memberQueryService;
 
     @MockitoBean
     protected PerformanceService performanceService;

--- a/src/test/java/team/unibusk/backend/global/support/ControllerTestSupport.java
+++ b/src/test/java/team/unibusk/backend/global/support/ControllerTestSupport.java
@@ -7,7 +7,6 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.assertj.MockMvcTester;
 import org.springframework.validation.beanvalidation.MethodValidationPostProcessor;
 import team.unibusk.backend.domain.applicationguide.application.ApplicationGuideService;
-import team.unibusk.backend.domain.member.application.MemberService;
 import team.unibusk.backend.domain.performance.application.PerformanceService;
 import team.unibusk.backend.domain.performanceLocation.application.PerformanceLocationService;
 import team.unibusk.backend.global.auth.application.auth.AuthService;


### PR DESCRIPTION
## 관련 이슈
- #202

## Summary

Member 도메인에 CQS 패턴을 적용하여 조회와 변경 책임을 분리합니다.
MemberService를 MemberCommandService, MemberQueryService로 나누고 Controller와 테스트도 동일하게 분리합니다.

## Tasks

- MemberService → MemberCommandService, MemberQueryService 분리
- MemberController, MemberDocsController → MemberCommandController, MemberCommandDocsController, MemberQueryController, MemberQueryDocsController 분리
- MemberService, MemberController, MemberDocsController 삭제
- MemberServiceTest → MemberCommandServiceTest, MemberQueryServiceTest 분리
- MemberControllerTest → MemberCommandControllerTest, MemberQueryControllerTest 분리
- ControllerTestSupport MemberService → MemberCommandService, MemberQueryService로 교체


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Member 도메인에 CQS 패턴을 적용하여 쿼리와 커맨드 책임을 분리했습니다.

### 🗑️ 제거
- `MemberService` 클래스 삭제  
  - 이유: 쿼리와 커맨드 책임을 분리하기 위해 역할별 서비스(`MemberCommandService`, `MemberQueryService`)로 대체됨.
  - 효과: 단일 클래스에 혼재된 읽기/쓰기 로직이 제거되어 책임이 분명해짐.

- `MemberController` 클래스 삭제  
  - 이유: 쿼리 전용 컨트롤러와 커맨드 전용 컨트롤러로 분리하기 위해 삭제됨.
  - 효과: 라우팅과 의존성이 쿼리/커맨드별로 분리됨.

- `MemberDocsController` 인터페이스 삭제  
  - 이유: OpenAPI 문서를 쿼리/커맨드용으로 분리하기 위해 `MemberCommandDocsController`, `MemberQueryDocsController`로 대체됨.
  - 효과: API 문서가 책임별로 분리되어 명확해짐.

- `public MemberInfoResponse getMyInfo(Long memberId)` 메서드 (이전 `MemberService`) 삭제  
  - 이유: 읽기 메서드는 `MemberQueryService.getMyInfo(...)`로 이동했기 때문.
  - 효과: 커맨드 서비스에서 불필요한 읽기 API가 제거되어 의도한 책임(쓰기)만 남음.

- `GET /members/me` 엔드포인트 (기존 `MemberController` 내부) 삭제  
  - 이유: 쿼리 엔드포인트가 `MemberQueryController`로 이동했기 때문.
  - 효과: 엔드포인트 구현이 쿼리 전용 컨트롤러로 옮겨짐.

- 테스트 클래스 `MemberServiceTest`, `MemberControllerTest` 삭제  
  - 이유: 각각 `MemberCommandServiceTest`/`MemberQueryServiceTest`, `MemberCommandControllerTest`/`MemberQueryControllerTest`로 분할되었기 때문.
  - 효과: 테스트가 책임별로 분리되어 단위 테스트 범위가 명확해짐.

### ✨ 추가
- `MemberCommandService` 클래스 (`team.unibusk.backend.domain.member.application.command`)  
  - 변경 내용: 기존 커맨드(변경) 메서드만 보유, `public MemberNameUpdateResponse updateMemberName(MemberNameUpdateServiceRequest request)` 유지.  
  - 이유: 쓰기(명령) 책임만 담당하도록 분리.  
  - 효과: 쓰기 트랜잭션 처리 코드가 한곳에 모여 유지보수성이 향상됨(명령에 집중).

- `MemberQueryService` 클래스 (`team.unibusk.backend.domain.member.application.query`)  
  - 변경 내용: `@Service`로 추가, `@Transactional(readOnly = true)`가 적용된 `public MemberInfoResponse getMyInfo(Long memberId)` 메서드 추가.  
  - 이유: 읽기(조회) 책임을 전담하도록 분리.  
  - 효과: 조회 동작에 대해 읽기 전용 트랜잭션이 명시되어 데이터베이스 접근 의도를 분명히 함.

- `MemberCommandController` 클래스 (`team.unibusk.backend.domain.member.presentation.command`)  
  - 변경 내용: `@PatchMapping("/me") public ResponseEntity<MemberNameUpdateResponse> updateMemberName(@MemberId Long memberId, @Valid @RequestBody MemberNameUpdateRequest request)` 엔드포인트 제공, 의존성으로 `MemberCommandService` 주입.  
  - 이유: 쓰기 요청(이름 수정)을 처리하는 책임만 갖도록 분리.  
  - 효과: 컨트롤러가 쓰기 로직만 노출하여 라우트 책임이 분명해짐.

- `MemberCommandDocsController` 인터페이스 (`team.unibusk.backend.domain.member.presentation.command`)  
  - 변경 내용: `PATCH /members/me` 문서화 인터페이스로 추가.  
  - 이유: 커맨드 엔드포인트의 OpenAPI 문서를 분리해 명세를 분명히 함.  
  - 효과: 문서에서 쓰기 API만 명확히 표현됨.

- `MemberQueryController` 클래스 (`team.unibusk.backend.domain.member.presentation.query`)  
  - 변경 내용: `@GetMapping("/me") public ResponseEntity<MemberInfoResponse> getMyInfo(@MemberId Long memberId)` 엔드포인트 제공, 의존성으로 `MemberQueryService` 주입.  
  - 이유: 조회 요청을 전담하는 컨트롤러로 분리.  
  - 효과: 조회 라우트가 쿼리 전용 컨트롤러로 집중되어 역할이 명확해짐.

- `MemberQueryDocsController` 인터페이스 (`team/unibusk.backend.domain.member.presentation.query`)  
  - 변경 내용: `GET /members/me` 문서화, 응답 `200` 및 `401` 정의(401에 `ExceptionResponse` 스키마 지정).  
  - 이유: 쿼리 엔드포인트의 OpenAPI 문서를 분리해 명세를 분명히 함.  
  - 효과: 문서에서 조회 API의 응답 규약이 명확해짐.

- 테스트 추가:  
  - `MemberCommandServiceTest` — `MemberCommandService.updateMemberName(...)` 관련 성공/예외 경로 테스트 추가.  
  - `MemberQueryServiceTest` — `MemberQueryService.getMyInfo(...)`의 성공 경로와 `MemberNotFoundException` 예외 경로 테스트 추가.  
  - `MemberCommandControllerTest` — `MemberCommandController.updateMemberName(...)` 관련 테스트로 변경.  
  - `MemberQueryControllerTest` — `MemberQueryController.getMyInfo(...)`의 MVC 테스트(`GET /members/me`) 추가.  
  - 이유: 서비스/컨트롤러 책임 분리에 따라 테스트를 역할별로 분리함.  
  - 효과: 각 책임 영역에 대한 단위 테스트가 분리되어 실패 원인 파악이 쉬워짐.

- `ControllerTestSupport` 테스트 헬퍼 업데이트  
  - 변경 내용: `protected MemberService memberService` → `protected MemberCommandService memberCommandService` 변경 및 `protected MemberQueryService memberQueryService` 추가.  
  - 이유: 테스트 지원 코드가 분리된 서비스들을 주입하도록 동기화하기 위함.  
  - 효과: 컨트롤러 테스트에서 각각의 mock 서비스를 독립적으로 주입/제어할 수 있음.

### 🔧 변경
- 패키지/네이밍 변경  
  - 변경 내용: 원래의 `MemberService` → `team.unibusk.backend.domain.member.application.command.MemberCommandService`, `MemberQueryService`는 `...application.query` 패키지로 분리; 컨트롤러들도 `presentation.command` / `presentation.query`로 이동.  
  - 이유: 쿼리/커맨드 책임을 패키지 수준에서 분리하여 구조적으로 구분하기 위함.  
  - 효과: 코드 위치만으로도 해당 클래스의 역할을 빠르게 파악할 수 있음.

- 컨트롤러 인터페이스 구현 변경  
  - 변경 내용: 기존 컨트롤러가 구현하던 하나의 문서 인터페이스가 `MemberCommandDocsController` / `MemberQueryDocsController`로 분리되어 각 컨트롤러가 해당 인터페이스를 구현하도록 수정됨.  
  - 이유: OpenAPI 문서와 컨트롤러 구현을 책임별로 매핑하기 위함.  
  - 효과: API 문서와 구현의 일관성이 향상됨.

### 🐛 수정
- 테스트의 예외 경로 명시화  
  - 변경 내용: `MemberCommandServiceTest`와 `MemberQueryServiceTest`에 `MemberNotFoundException` 발생 시나리오를 추가/이동.  
  - 이유: 서비스 분리 후 각 서비스의 예외 발생 동작을 명확히 검증하기 위함.  
  - 효과: 예외 동작이 각 서비스별로 검증되어 회귀 방지에 도움됨.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->