### PR TITLE
Fix: docker-compose.yml DB_HOST 환경변수 제거

### DIFF
--- a/deployment/prod/docker/docker-compose.yml
+++ b/deployment/prod/docker/docker-compose.yml
@@ -11,7 +11,6 @@ services:
       - "host.docker.internal:host-gateway"
     environment:
       - SPRING_PROFILES_ACTIVE=prod
-      - DB_HOST=host.docker.internal
       - REDIS_HOST=host.docker.internal
       - JAVA_OPTS=-Xms256m -Xmx350m -XX:MaxMetaspaceSize=256m -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -XX:+UseContainerSupport
     ports:
@@ -38,7 +37,6 @@ services:
       - "host.docker.internal:host-gateway"
     environment:
       - SPRING_PROFILES_ACTIVE=prod
-      - DB_HOST=host.docker.internal
       - REDIS_HOST=host.docker.internal
       - JAVA_OPTS=-Xms256m -Xmx350m -XX:MaxMetaspaceSize=256m -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -XX:+UseContainerSupport
     ports:


### PR DESCRIPTION
## 관련 이슈
- #217

## Summary
docker-compose.yml에 하드코딩된 DB_HOST 환경변수를 제거하여 application-prod.yml의 Supabase PostgreSQL 설정이 정상적으로 적용되도록 수정합니다.

## Tasks
- blue, green 서비스에서 `DB_HOST=host.docker.internal` 환경변수 제거