### PR TITLE
Fix: nginx 미실행 상태에서 배포 실패 방지

### DIFF
--- a/deployment/prod/deploy.sh
+++ b/deployment/prod/deploy.sh
@@ -74,7 +74,9 @@ rollback() {
 
   sudo cp "$NGINX_DIR/unibusk-$CURRENT.conf" /etc/nginx/conf.d/default.conf
   sudo nginx -t
-  sudo nginx -s reload
+  if ! sudo nginx -s reload 2>/dev/null; then
+    sudo nginx
+  fi
 
   docker compose -f "$COMPOSE" --env-file "$APP_ENV_FILE" rm -f "$NEXT" || true
 
@@ -141,7 +143,9 @@ sleep $WARMUP_DELAY
 # Nginx 교체
 sudo cp "$NGINX_DIR/unibusk-$NEXT.conf" /etc/nginx/conf.d/default.conf
 sudo nginx -t
-sudo nginx -s reload
+if ! sudo nginx -s reload 2>/dev/null; then
+  sudo nginx
+fi
 
 # 기존 컨테이너 정리 (graceful shutdown 대기)
 docker compose -f "$COMPOSE" --env-file "$APP_ENV_FILE" stop -t 35 "$CURRENT"

--- a/deployment/prod/deploy.sh
+++ b/deployment/prod/deploy.sh
@@ -74,7 +74,10 @@ rollback() {
 
   sudo cp "$NGINX_DIR/unibusk-$CURRENT.conf" /etc/nginx/conf.d/default.conf
   sudo nginx -t
-  if ! sudo nginx -s reload 2>/dev/null; then
+  if pgrep -x nginx >/dev/null 2>&1; then
+    sudo nginx -s reload
+  else
+    log "nginx not running — starting instead of reload"
     sudo nginx
   fi
 
@@ -143,7 +146,10 @@ sleep $WARMUP_DELAY
 # Nginx 교체
 sudo cp "$NGINX_DIR/unibusk-$NEXT.conf" /etc/nginx/conf.d/default.conf
 sudo nginx -t
-if ! sudo nginx -s reload 2>/dev/null; then
+if pgrep -x nginx >/dev/null 2>&1; then
+  sudo nginx -s reload
+else
+  log "nginx not running — starting instead of reload"
   sudo nginx
 fi
 


### PR DESCRIPTION
## 관련 이슈
- #221

## Summary
EC2 재시작 후 nginx가 실행되지 않은 상태에서 배포 시 `nginx -s reload`가 실패하여 롤백이 발생하는 문제를 수정합니다.
nginx가 미실행 상태일 때 reload 대신 start로 fallback하도록 배포 스크립트를 개선합니다.

## Tasks
- 배포 시 nginx reload 실패 시 nginx start로 fallback 처리
- 롤백 시 nginx reload 실패 시 nginx start로 fallback 처리


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## PR 요약

배포 스크립트에서 nginx가 미실행 상태일 때 reload 실패로 인한 배포 실패를 방지하기 위해 조건부 폴백 로직을 추가했습니다.

---

## 🐛 수정

### `deployment/prod/deploy.sh`의 nginx reload 폴백 처리

**변경 내용**
- **롤백 함수** (라인 77-79)와 **메인 배포 경로** (라인 146-148)의 두 위치에서 nginx 재로드 로직 수정
- `sudo nginx -s reload` 실행 시 에러를 무시(`2>/dev/null`)하고 실패하면 `sudo nginx` 명령으로 폴백하는 조건문 추가

**변경 이유**
- EC2 재시작 후 nginx가 미실행 상태에서 `nginx -s reload` 명령 실패로 인한 배포 스크립트 중단 방지
- nginx 설정 유효성 검증(`sudo nginx -t`)은 유지하면서 reload 실패에 대한 탄력성 확보

**변경 효과**
- nginx 미실행 상태에서도 `start` 명령으로 자동 폴백되어 배포 성공
- 불필요한 롤백 발생 제거로 배포 안정성 향상

<!-- end of auto-generated comment: release notes by coderabbit.ai -->