### PR TITLE
Refactor: 공연자 이름 최대 길이 15자 → 20자로 수정

### DIFF
--- a/src/main/java/team/unibusk/backend/domain/performance/domain/Performer.java
+++ b/src/main/java/team/unibusk/backend/domain/performance/domain/Performer.java
@@ -15,7 +15,7 @@ public class Performer {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false, length = 15)
+    @Column(nullable = false, length = 20)
     private String name;
 
     @Column(nullable = false, length = 50)

--- a/src/main/java/team/unibusk/backend/domain/performance/presentation/request/PerformanceRegisterRequest.java
+++ b/src/main/java/team/unibusk/backend/domain/performance/presentation/request/PerformanceRegisterRequest.java
@@ -47,7 +47,7 @@ public record PerformanceRegisterRequest (
     public record PerformerRegisterRequest(
             //공연자 정보
             @NotBlank(message = "공연자 이름은 필수 입력 항목입니다.")
-            @Size(max = 15, message = "공연자 이름은 최대 15자 입니다.")
+            @Size(max = 20, message = "공연자 이름은 최대 15자 입니다.")
             String name,
 
             @NotBlank(message = "이메일은 필수 입력 항목입니다.")

--- a/src/main/java/team/unibusk/backend/domain/performance/presentation/request/PerformanceRegisterRequest.java
+++ b/src/main/java/team/unibusk/backend/domain/performance/presentation/request/PerformanceRegisterRequest.java
@@ -47,7 +47,7 @@ public record PerformanceRegisterRequest (
     public record PerformerRegisterRequest(
             //공연자 정보
             @NotBlank(message = "공연자 이름은 필수 입력 항목입니다.")
-            @Size(max = 20, message = "공연자 이름은 최대 15자 입니다.")
+            @Size(max = 20, message = "공연자 이름은 최대 20자 입니다.")
             String name,
 
             @NotBlank(message = "이메일은 필수 입력 항목입니다.")


### PR DESCRIPTION
## 관련 이슈
- #223

## Summary

공연자 이름 최대 길이 제한이 15자로 설정되어 있어 실제 사용 시 불편함이 있어 20자로 수정합니다.

## Tasks

- PerformanceRegisterRequest 공연자 이름 @Size(max = 15 → 20) 수정
- Performer 엔티티 @Column(length = 15 → 20) 수정
