### PR TITLE
Refactor: ApplicationGuide의 PerformanceLocation 객체 참조를 ID 참조로 변경

### DIFF
--- a/src/main/java/team/unibusk/backend/domain/applicationguide/application/dto/response/ApplicationGuideResponse.java
+++ b/src/main/java/team/unibusk/backend/domain/applicationguide/application/dto/response/ApplicationGuideResponse.java
@@ -22,7 +22,7 @@ public record ApplicationGuideResponse(
     public static ApplicationGuideResponse from(ApplicationGuide applicationGuide) {
         return ApplicationGuideResponse.builder()
                 .applicationGuideId(applicationGuide.getId())
-                .performanceLocationId(applicationGuide.getPerformanceLocation().getId())
+                .performanceLocationId(applicationGuide.getPerformanceLocationId())
                 .content(applicationGuide.getContent())
                 .build();
     }

--- a/src/main/java/team/unibusk/backend/domain/applicationguide/domain/ApplicationGuide.java
+++ b/src/main/java/team/unibusk/backend/domain/applicationguide/domain/ApplicationGuide.java
@@ -2,7 +2,6 @@ package team.unibusk.backend.domain.applicationguide.domain;
 
 import jakarta.persistence.*;
 import lombok.*;
-import team.unibusk.backend.domain.performanceLocation.domain.PerformanceLocation;
 import team.unibusk.backend.global.domain.BaseTimeEntity;
 
 @Getter

--- a/src/main/java/team/unibusk/backend/domain/applicationguide/domain/ApplicationGuide.java
+++ b/src/main/java/team/unibusk/backend/domain/applicationguide/domain/ApplicationGuide.java
@@ -15,7 +15,7 @@ public class ApplicationGuide extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false)
+    @Column(name = "performance_location_id", nullable = false)
     private Long performanceLocationId;
 
     @Column(nullable = false)

--- a/src/main/java/team/unibusk/backend/domain/applicationguide/domain/ApplicationGuide.java
+++ b/src/main/java/team/unibusk/backend/domain/applicationguide/domain/ApplicationGuide.java
@@ -17,16 +17,15 @@ public class ApplicationGuide extends BaseTimeEntity {
     private Long id;
 
     @Column(nullable = false)
+    private Long performanceLocationId;
+
+    @Column(nullable = false)
     private String content;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "performance_location_id", nullable = false)
-    private PerformanceLocation performanceLocation;
-
-    public static ApplicationGuide create(String content, PerformanceLocation performanceLocation) {
+    public static ApplicationGuide create(String content, Long performanceLocationId) {
         return ApplicationGuide.builder()
                 .content(content)
-                .performanceLocation(performanceLocation)
+                .performanceLocationId(performanceLocationId)
                 .build();
     }
 

--- a/src/main/java/team/unibusk/backend/domain/performanceLocation/application/PerformanceLocationExcelService.java
+++ b/src/main/java/team/unibusk/backend/domain/performanceLocation/application/PerformanceLocationExcelService.java
@@ -192,7 +192,7 @@ public class PerformanceLocationExcelService {
         for (String content : contents) {
             if (StringUtils.hasText(content)) {
                 // 정의하신 create 정적 팩토리 메서드 활용
-                guides.add(ApplicationGuide.create(content, savedLocation));
+                guides.add(ApplicationGuide.create(content, savedLocation.getId()));
             }
         }
 

--- a/src/test/java/team/unibusk/backend/domain/applicationguide/application/ApplicationGuideServiceTest.java
+++ b/src/test/java/team/unibusk/backend/domain/applicationguide/application/ApplicationGuideServiceTest.java
@@ -38,7 +38,7 @@ class ApplicationGuideServiceTest extends UnitTestSupport {
         ReflectionTestUtils.setField(guide1, "id", 1L);
         ReflectionTestUtils.setField(guide2, "id", 2L);
 
-        given(performanceLocationRepository.findById(performanceLocationId)).willReturn(location);
+        given(performanceLocationRepository.findById(performanceLocationId)).willReturn(null);
         given(applicationGuideRepository.findAllByPerformanceLocationId(performanceLocationId))
                 .willReturn(List.of(guide1, guide2));
 

--- a/src/test/java/team/unibusk/backend/domain/applicationguide/application/ApplicationGuideServiceTest.java
+++ b/src/test/java/team/unibusk/backend/domain/applicationguide/application/ApplicationGuideServiceTest.java
@@ -8,8 +8,6 @@ import team.unibusk.backend.domain.applicationguide.application.dto.response.App
 import team.unibusk.backend.domain.applicationguide.domain.ApplicationGuide;
 import team.unibusk.backend.domain.applicationguide.domain.ApplicationGuideRepository;
 import team.unibusk.backend.domain.performance.presentation.exception.PerformanceLocationNotFoundException;
-import team.unibusk.backend.domain.performanceLocation.domain.PerformanceLocation;
-import team.unibusk.backend.domain.performanceLocation.domain.PerformanceLocationFixture;
 import team.unibusk.backend.domain.performanceLocation.domain.PerformanceLocationRepository;
 import team.unibusk.backend.global.support.UnitTestSupport;
 
@@ -35,10 +33,8 @@ class ApplicationGuideServiceTest extends UnitTestSupport {
     void 신청_가이드_목록을_정상_조회한다() {
         Long performanceLocationId = 1L;
 
-        PerformanceLocation location = PerformanceLocationFixture.createLocation(performanceLocationId, "홍대");
-
-        ApplicationGuide guide1 = ApplicationGuide.create("사전 신청 필수", location);
-        ApplicationGuide guide2 = ApplicationGuide.create("장비 직접 지참", location);
+        ApplicationGuide guide1 = ApplicationGuide.create("사전 신청 필수", performanceLocationId);
+        ApplicationGuide guide2 = ApplicationGuide.create("장비 직접 지참", performanceLocationId);
         ReflectionTestUtils.setField(guide1, "id", 1L);
         ReflectionTestUtils.setField(guide2, "id", 2L);
 
@@ -61,9 +57,7 @@ class ApplicationGuideServiceTest extends UnitTestSupport {
     void 신청_가이드가_없으면_빈_목록을_반환한다() {
         Long performanceLocationId = 1L;
 
-        PerformanceLocation location = PerformanceLocationFixture.createLocation(performanceLocationId, "홍대");
-
-        given(performanceLocationRepository.findById(performanceLocationId)).willReturn(location);
+        given(performanceLocationRepository.findById(performanceLocationId)).willReturn(null);
         given(applicationGuideRepository.findAllByPerformanceLocationId(performanceLocationId))
                 .willReturn(List.of());
 

--- a/src/test/java/team/unibusk/backend/domain/applicationguide/application/ApplicationGuideServiceTest.java
+++ b/src/test/java/team/unibusk/backend/domain/applicationguide/application/ApplicationGuideServiceTest.java
@@ -8,6 +8,8 @@ import team.unibusk.backend.domain.applicationguide.application.dto.response.App
 import team.unibusk.backend.domain.applicationguide.domain.ApplicationGuide;
 import team.unibusk.backend.domain.applicationguide.domain.ApplicationGuideRepository;
 import team.unibusk.backend.domain.performance.presentation.exception.PerformanceLocationNotFoundException;
+import team.unibusk.backend.domain.performanceLocation.domain.PerformanceLocation;
+import team.unibusk.backend.domain.performanceLocation.domain.PerformanceLocationFixture;
 import team.unibusk.backend.domain.performanceLocation.domain.PerformanceLocationRepository;
 import team.unibusk.backend.global.support.UnitTestSupport;
 
@@ -32,13 +34,14 @@ class ApplicationGuideServiceTest extends UnitTestSupport {
     @Test
     void 신청_가이드_목록을_정상_조회한다() {
         Long performanceLocationId = 1L;
+        PerformanceLocation location = PerformanceLocationFixture.createLocation(performanceLocationId, "홍대");
 
         ApplicationGuide guide1 = ApplicationGuide.create("사전 신청 필수", performanceLocationId);
         ApplicationGuide guide2 = ApplicationGuide.create("장비 직접 지참", performanceLocationId);
         ReflectionTestUtils.setField(guide1, "id", 1L);
         ReflectionTestUtils.setField(guide2, "id", 2L);
 
-        given(performanceLocationRepository.findById(performanceLocationId)).willReturn(null);
+        given(performanceLocationRepository.findById(performanceLocationId)).willReturn(location);
         given(applicationGuideRepository.findAllByPerformanceLocationId(performanceLocationId))
                 .willReturn(List.of(guide1, guide2));
 
@@ -56,8 +59,9 @@ class ApplicationGuideServiceTest extends UnitTestSupport {
     @Test
     void 신청_가이드가_없으면_빈_목록을_반환한다() {
         Long performanceLocationId = 1L;
+        PerformanceLocation location = PerformanceLocationFixture.createLocation(performanceLocationId, "홍대");
 
-        given(performanceLocationRepository.findById(performanceLocationId)).willReturn(null);
+        given(performanceLocationRepository.findById(performanceLocationId)).willReturn(location);
         given(applicationGuideRepository.findAllByPerformanceLocationId(performanceLocationId))
                 .willReturn(List.of());
 


### PR DESCRIPTION
## 관련 이슈
- #225 

## Summary

ApplicationGuide의 PerformanceLocation 객체 참조를 ID 참조로 변경합니다.

## Tasks

- `ApplicationGuide` 엔티티의 `@ManyToOne PerformanceLocation` 필드를 `Long performanceLocationId`로 변경
- `ApplicationGuide.create()` 팩토리 메서드 파라미터를 `PerformanceLocation` → `Long performanceLocationId`로 변경
- `ApplicationGuideResponse`에서 `getPerformanceLocation().getId()` → `getPerformanceLocationId()`로 수정
- `PerformanceLocationExcelService`에서 `ApplicationGuide.create()` 인자를 `savedLocation.getId()`로 수정
- `ApplicationGuideServiceTest` 테스트 코드 수정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## 한 줄 요약
`ApplicationGuide` 엔티티의 `PerformanceLocation` 객체 직접 참조를 `Long performanceLocationId` ID 참조로 변경하여 순환 참조를 제거하고 불필요한 데이터베이스 조인을 방지합니다.

---

## 🗑️ 제거

- **`ApplicationGuide` 클래스**의 `@ManyToOne(fetch = FetchType.LAZY) @JoinColumn(name = "performance_location_id", nullable = false) PerformanceLocation performanceLocation` 필드 제거
  - 이유: 객체 참조 제거로 엔티티 간 순환 참조 가능성 제거 및 불필요한 Lazy loading 방지

---

## ✨ 추가

- **`ApplicationGuide` 클래스**에 `@Column(name = "performance_location_id", nullable = false) Long performanceLocationId` 필드 추가
  - 이유: 성능 위치 ID를 직접 저장하여 객체 참조 대신 값 타입 참조 사용

---

## 🔧 변경

- **팩토리 메서드 시그니처 변경**
  - `ApplicationGuide.create(String content, PerformanceLocation performanceLocation)` → `create(String content, Long performanceLocationId)`
  - 이유: 팩토리 파라미터를 객체에서 ID로 변경하여 엔티티 간 의존성 감소

- **DTO 매핑 변경**
  - `ApplicationGuideResponse.from(ApplicationGuide applicationGuide)`에서 `applicationGuide.getPerformanceLocation().getId()` → `applicationGuide.getPerformanceLocationId()`로 변경

- **서비스 호출 변경**
  - `PerformanceLocationExcelService.saveEntity()`에서 `ApplicationGuide.create(content, savedLocation)` → `ApplicationGuide.create(content, savedLocation.getId())`로 변경

- **테스트 코드 수정**
  - `ApplicationGuideServiceTest`에서 `ApplicationGuide.create()` 호출을 `PerformanceLocation` 객체 대신 `performanceLocationId` (Long)로 생성하도록 변경
  - 테스트 설정에서 `PerformanceLocationFixture`를 사용해 null 대신 유효한 `PerformanceLocation`을 반환하도록 수정하여 테스트 안정성 개선
  - 일부 불필요한 import 제거 및 소소한 정리 적용

---

## 효과

- 데이터베이스 조회 최적화: 불필요한 `PerformanceLocation` 조인/로딩 제거  
- 엔티티 설계 단순화: 순환 참조 위험 감소  
- 테스트 안정성 향상 및 유지보수성 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->