### PR TITLE
Feat: 공연 상세 조회 응답에 memberId 필드 추가

### DIFF
--- a/src/main/java/team/unibusk/backend/domain/performance/application/dto/response/PerformanceDetailResponse.java
+++ b/src/main/java/team/unibusk/backend/domain/performance/application/dto/response/PerformanceDetailResponse.java
@@ -13,6 +13,9 @@ import java.util.List;
 @Builder
 public record PerformanceDetailResponse (
 
+        @Schema(description = "회원 ID", example = "1")
+        Long memberId,
+
         @Schema(description = "공연 고유 ID", example = "101")
         Long performanceId,
 
@@ -61,6 +64,7 @@ public record PerformanceDetailResponse (
                 PerformanceLocation location
         ) {
                 return PerformanceDetailResponse.builder()
+                        .memberId(performance.getMemberId())
                         .performanceId(performance.getId())
                         .title(performance.getTitle())
                         .performanceDate(performance.getPerformanceDate())

--- a/src/test/java/team/unibusk/backend/domain/performance/presentation/query/PerformanceQueryControllerTest.java
+++ b/src/test/java/team/unibusk/backend/domain/performance/presentation/query/PerformanceQueryControllerTest.java
@@ -130,6 +130,7 @@ class PerformanceQueryControllerTest extends ControllerTestSupport {
         LocalDateTime fixedNow = LocalDateTime.of(2027, 7, 30, 14, 0);
 
         PerformanceDetailResponse performance = PerformanceDetailResponse.builder()
+                .memberId(1L)
                 .performanceId(1L)
                 .locationName("걷고싶은거리")
                 .title("UNIBUSK 버스킹")


### PR DESCRIPTION
## 관련 이슈
- #228 

## Summary

공연 상세 조회 응답에 memberId 필드 추가

## Tasks

- Response DTO에 memberId 필드 추가
- 서비스 및 컨트롤러 응답에 memberId 포함되도록 수정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 요약

공연 상세 조회 응답 DTO에 memberId 필드를 추가하여, 공연 상세 조회 시 공연 등록자의 회원 정보를 응답에 포함시키도록 수정했습니다.

## 작업 내역

- **PerformanceDetailResponse** 응답 DTO에 `memberId` 레코드 컴포넌트 추가
  - Swagger 문서화용 `@Schema` 어노테이션 적용 (회원 ID 설명 및 예시값 포함)
  - `from()` 팩토리 메서드에서 `.memberId(performance.getMemberId())` 매핑 추가

- **PerformanceQueryControllerTest** 테스트 코드 수정
  - "공연_ID로_조회하면_200과_공연_상세정보를_반환한다()" 테스트에서 PerformanceDetailResponse 빌더에 `.memberId(1L)` 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->