### PR TITLE
Refactor: 미사용 Member.firstLogin 필드 제거

### DIFF
--- a/src/main/java/team/unibusk/backend/domain/member/domain/Member.java
+++ b/src/main/java/team/unibusk/backend/domain/member/domain/Member.java
@@ -29,14 +29,11 @@ public class Member extends BaseTimeEntity {
 
     private String externalId;
 
-    private boolean firstLogin;
-
     public static Member from(AuthAttributes attributes) {
         return Member.builder()
                 .email(attributes.getEmail())
                 .provider(attributes.getProvider())
                 .externalId(attributes.getExternalId())
-                .firstLogin(true)
                 .build();
     }
 

--- a/src/test/java/team/unibusk/backend/domain/member/domain/MemberTest.java
+++ b/src/test/java/team/unibusk/backend/domain/member/domain/MemberTest.java
@@ -19,15 +19,6 @@ class MemberTest {
     }
 
     @Test
-    void OAuth_인증정보로_회원을_생성하면_최초_로그인_상태다() {
-        AuthAttributes attributes = 인증정보("test@email.com", "kakao-123");
-
-        Member member = Member.from(attributes);
-
-        assertThat(member.isFirstLogin()).isTrue();
-    }
-
-    @Test
     void 이름을_생성하면_이름이_설정된다() {
         Member member = 회원("test@email.com", "kakao-123");
 


### PR DESCRIPTION
## 관련 이슈
- #230 

## Summary

DB에 저장만 되고 읽히지 않는 `Member.firstLogin` 필드를 제거합니다.

## Tasks

- DB에 저장만 되고 읽히지 않는 `Member.firstLogin` 필드 제거
- `Member.from()`의 `.firstLogin(true)` 제거


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

Member 엔티티에서 데이터베이스에 저장되었으나 읽지 않던 미사용 필드를 제거하는 리팩토링을 수행했습니다.

## Task by CodeRabbit

- Member 클래스의 미사용 필드 `private boolean firstLogin;` 제거
- Member.from() static factory 메서드에서 `.firstLogin(true)` 빌더 호출 제거

<!-- end of auto-generated comment: release notes by coderabbit.ai -->