### PR TITLE
Fix: SignatureException 발생 시 refresh token 쿠키 미삭제 버그 수정

### DIFF
--- a/src/main/java/team/unibusk/backend/global/jwt/filter/JwtTokenFilter.java
+++ b/src/main/java/team/unibusk/backend/global/jwt/filter/JwtTokenFilter.java
@@ -1,6 +1,7 @@
 package team.unibusk.backend.global.jwt.filter;
 
 import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.security.SignatureException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -71,7 +72,7 @@ public class JwtTokenFilter extends OncePerRequestFilter {
     private String reissueAccessTokenSafely(HttpServletRequest request, HttpServletResponse response) {
         try {
             return reissueAccessToken(request, response);
-        } catch (ExpiredJwtException e) {
+        } catch (ExpiredJwtException | SignatureException e) {
             log.debug("Refresh token expired during token reissue attempt");
             throw new RefreshTokenNotValidException();
         }

--- a/src/main/java/team/unibusk/backend/global/jwt/filter/JwtTokenFilter.java
+++ b/src/main/java/team/unibusk/backend/global/jwt/filter/JwtTokenFilter.java
@@ -72,8 +72,11 @@ public class JwtTokenFilter extends OncePerRequestFilter {
     private String reissueAccessTokenSafely(HttpServletRequest request, HttpServletResponse response) {
         try {
             return reissueAccessToken(request, response);
-        } catch (ExpiredJwtException | SignatureException e) {
+        } catch (ExpiredJwtException e) {
             log.debug("Refresh token expired during token reissue attempt");
+            throw new RefreshTokenNotValidException();
+        } catch (SignatureException e) {
+            log.debug("Refresh token signature mismatch during token reissue attempt");
             throw new RefreshTokenNotValidException();
         }
     }


### PR DESCRIPTION
## 관련 이슈
- #232 

## Summary

JWT 시크릿 키 불일치로 `SignatureException` 발생 시 refresh token 쿠키가 삭제되지 않아 유저가 인증 루프에 빠지는 버그를 수정합니다.

## Tasks

- `reissueAccessTokenSafely`에서 `SignatureException` 미처리로 인한 refresh token 쿠키 미삭제 버그 수정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

JWT 토큰 재발급 과정에서 `SignatureException` 예외를 처리하도록 개선했습니다. 기존에는 access token이 만료되었을 때 refresh token을 사용하여 토큰을 재발급하는 중 JWT 시크릿 키 불일치로 `SignatureException`이 발생하면 이를 처리하지 않아 refresh token 쿠키가 삭제되지 않는 버그가 있었습니다. 이제 `SignatureException`을 `ExpiredJwtException`과 함께 처리하여 예외 발생 시 `RefreshTokenNotValidException`을 던지고, 이를 통해 refresh token과 access token 쿠키가 모두 삭제되도록 수정했습니다.

## Task by CodeRabbit

- `JwtTokenFilter`의 `reissueAccessTokenSafely` 메서드에서 `SignatureException` import 추가
- `reissueAccessTokenSafely` 메서드의 catch 블록에서 `ExpiredJwtException` 처리와 함께 `SignatureException`도 처리하도록 수정하여, 예외 발생 시 `RefreshTokenNotValidException`을 던지고 refresh token 쿠키가 삭제되도록 개선

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SWYP12-UNIBUSK/unibusk-backend/pull/233)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->