### PR TITLE
Refactor: Performance의 자식 엔티티 직접 연관관계를 ID 참조 방식으로 변경

### DIFF
--- a/src/main/java/team/unibusk/backend/domain/performance/application/command/PerformanceCommandService.java
+++ b/src/main/java/team/unibusk/backend/domain/performance/application/command/PerformanceCommandService.java
@@ -12,19 +12,15 @@ import team.unibusk.backend.domain.performance.application.dto.request.Performan
 import team.unibusk.backend.domain.performance.application.dto.request.PerformanceUpdateServiceRequest;
 import team.unibusk.backend.domain.performance.application.dto.response.PerformanceDetailResponse;
 import team.unibusk.backend.domain.performance.application.dto.response.PerformanceRegisterResponse;
-import team.unibusk.backend.domain.performance.domain.Performance;
-import team.unibusk.backend.domain.performance.domain.PerformanceImage;
-import team.unibusk.backend.domain.performance.domain.PerformanceRepository;
-import team.unibusk.backend.domain.performance.domain.Performer;
+import team.unibusk.backend.domain.performance.domain.*;
 import team.unibusk.backend.domain.performance.presentation.exception.PerformanceRegistrationFailedException;
 import team.unibusk.backend.domain.performanceLocation.domain.PerformanceLocation;
 import team.unibusk.backend.domain.performanceLocation.domain.PerformanceLocationRepository;
 import team.unibusk.backend.global.file.application.FileUploadService;
 
-import java.util.Collections;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
 @RequiredArgsConstructor
 @Transactional
@@ -33,41 +29,31 @@ public class PerformanceCommandService {
 
     private final MemberRepository memberRepository;
     private final FileUploadService fileUploadService;
+    private final PerformerRepository performerRepository;
     private final PerformanceRepository performanceRepository;
+    private final PerformanceImageRepository performanceImageRepository;
     private final PerformanceLocationRepository performanceLocationRepository;
 
     private static final String PERFORMANCE_FOLDER = "performances";
 
     @Transactional
     public PerformanceRegisterResponse register(PerformanceRegisterServiceRequest request) {
-        List<PerformanceImage> images = uploadImages(request.images());
-        List<String> uploadedImageUrls = images.stream()
-                .map(PerformanceImage::getImageUrl)
-                .toList();
+        String uploadedImageUrl = uploadImage(request.image());
 
-        TransactionSynchronizationManager.registerSynchronization(
-                new TransactionSynchronization() {
-                    @Override
-                    public void afterCompletion(int status) {
-                        if (status != TransactionSynchronization.STATUS_COMMITTED) {
-                            uploadedImageUrls.forEach(fileUploadService::delete);
+        if(uploadedImageUrl != null) {
+            TransactionSynchronizationManager.registerSynchronization(
+                    new TransactionSynchronization() {
+                        @Override
+                        public void afterCompletion(int status) {
+                            if (status != TransactionSynchronization.STATUS_COMMITTED) {
+                                fileUploadService.delete(uploadedImageUrl);
+                            }
                         }
                     }
-                }
-        );
+            );
+        }
 
-        try{
-            List<Performer> performers = (request.performers() == null || request.performers().isEmpty())
-                    ? Collections.emptyList()
-                    : request.performers().stream()
-                    .map(p -> Performer.builder()
-                            .name(p.name())
-                            .email(p.email())
-                            .phoneNumber(p.phoneNumber())
-                            .instagram(p.instagram())
-                            .build())
-                    .collect(Collectors.toList());
-
+        try {
             Performance performance = Performance.builder()
                     .memberId(request.memberId())
                     .performanceLocationId(request.performanceLocationId())
@@ -77,24 +63,42 @@ public class PerformanceCommandService {
                     .performanceDate(request.performanceDate())
                     .startTime(request.startTime())
                     .endTime(request.endTime())
-                    .images(images)
-                    .performers(performers)
                     .build();
 
-            Performance saved = performanceRepository.save(performance);
+            Performance savedPerformance = performanceRepository.save(performance);
+            Long performanceId = savedPerformance.getId();
+
+            if(request.performers() != null && !request.performers().isEmpty()) {
+                List<Performer> performers = request.performers().stream()
+                        .map(p -> Performer.builder()
+                                .performanceId(performanceId)
+                                .name(p.name())
+                                .email(p.email())
+                                .phoneNumber(p.phoneNumber())
+                                .instagram(p.instagram())
+                                .build())
+                        .collect(Collectors.toList());
+                performerRepository.saveAll(performers);
+            }
+
+            if(uploadedImageUrl != null) {
+                PerformanceImage image = PerformanceImage.builder()
+                        .performanceId(performanceId)
+                        .imageUrl(uploadedImageUrl)
+                        .build();
+                performanceImageRepository.save(image);
+            }
 
             return PerformanceRegisterResponse.builder()
-                    .performanceId(saved.getId())
+                    .performanceId(performanceId)
                     .build();
-
-        }catch(Exception e){
+        } catch (Exception e) {
             throw new PerformanceRegistrationFailedException();
         }
     }
 
     public PerformanceDetailResponse updatePerformance(PerformanceUpdateServiceRequest request) {
         Performance performance = performanceRepository.findDetailById(request.performanceId());
-
         Member member = memberRepository.findByMemberId(request.memberId());
 
         performance.validateOwner(member.getId());
@@ -109,95 +113,103 @@ public class PerformanceCommandService {
                 request.performanceLocationId()
         );
 
-        performance.clearPerformers();
-        request.performers().forEach(p ->
-                performance.addPerformer(
-                        Performer.builder()
-                                .name(p.name())
-                                .email(p.email())
-                                .phoneNumber(p.phoneNumber())
-                                .instagram(p.instagram())
-                                .build()
-                )
-        );
+        List<Performer> finalPerformers = new ArrayList<>();
+        performerRepository.deleteByPerformanceId(performance.getId());
 
-        List<PerformanceImage> newImages = uploadImages(request.images());
+        if (request.performers() != null && !request.performers().isEmpty()) {
+            finalPerformers = request.performers().stream()
+                    .map(p -> Performer.builder()
+                            .performanceId(performance.getId())
+                            .name(p.name())
+                            .email(p.email())
+                            .phoneNumber(p.phoneNumber())
+                            .instagram(p.instagram())
+                            .build())
+                    .collect(Collectors.toList());
+            performerRepository.saveAll(finalPerformers);
+        }
 
-        if (!newImages.isEmpty()) {
-            List<String> deleteTargetUrls = performance.getImages().stream()
-                    .map(PerformanceImage::getImageUrl)
-                    .toList();
-            List<String> newImageUrls = newImages.stream()
-                    .map(PerformanceImage::getImageUrl)
-                    .toList();
+        String finalImageUrl = null;
+        String newImageUrl = uploadImage(request.image());
 
-            performance.clearImages();
-            newImages.forEach(performance::addImage);
+        if (newImageUrl != null) {
+            PerformanceImage oldImage = performanceImageRepository.findByPerformanceId(performance.getId());
+            String deleteTargetUrl = oldImage.getImageUrl();
+
+            performanceImageRepository.deleteByPerformanceId(performance.getId());
+
+            PerformanceImage newImage = PerformanceImage.builder()
+                    .performanceId(performance.getId())
+                    .imageUrl(newImageUrl)
+                    .build();
+            performanceImageRepository.save(newImage);
+
+            finalImageUrl = newImageUrl;
 
             TransactionSynchronizationManager.registerSynchronization(
                     new TransactionSynchronization() {
                         @Override
                         public void afterCommit() {
-                            deleteTargetUrls.forEach(fileUploadService::delete);
+                            fileUploadService.delete(deleteTargetUrl);
                         }
 
                         @Override
                         public void afterCompletion(int status) {
                             if (status != TransactionSynchronization.STATUS_COMMITTED) {
-                                newImageUrls.forEach(fileUploadService::delete);
+                                fileUploadService.delete(newImageUrl);
                             }
                         }
                     }
             );
+        } else {
+            PerformanceImage existingImage = performanceImageRepository.findByPerformanceId(performance.getId());
+            if (existingImage != null) {
+                finalImageUrl = existingImage.getImageUrl();
+            }
         }
 
         PerformanceLocation location =
                 performanceLocationRepository.findById(performance.getPerformanceLocationId());
 
-        return PerformanceDetailResponse.from(performance, location);
+        return PerformanceDetailResponse.from(performance, location, finalImageUrl, finalPerformers);
     }
 
     public void deletePerformance(Long performanceId, Long memberId) {
         Performance performance = performanceRepository.findById(performanceId);
-
         Member member = memberRepository.findByMemberId(memberId);
 
         performance.validateOwner(member.getId());
 
-        List<String> deleteTargetUrls = performance.getImages().stream()
-                .map(PerformanceImage::getImageUrl)
-                .toList();
+        PerformanceImage image = performanceImageRepository.findByPerformanceId(performanceId);
 
-        performanceRepository.delete(performance);
+        if(image != null) {
+            String deleteTargetUrl = image.getImageUrl();
 
-        TransactionSynchronizationManager.registerSynchronization(
-                new TransactionSynchronization() {
-                    @Override
-                    public void afterCommit() {
-                        deleteTargetUrls.forEach(fileUploadService::delete);
+            performanceImageRepository.deleteByPerformanceId(performanceId);
+
+            TransactionSynchronizationManager.registerSynchronization(
+                    new TransactionSynchronization() {
+                        @Override
+                        public void afterCommit() {
+                            fileUploadService.delete(deleteTargetUrl);
+                        }
                     }
-                }
-        );
-    }
-
-    private List<PerformanceImage> uploadImages(List<MultipartFile> files) {
-        if (files == null || files.isEmpty() || files.stream().allMatch(MultipartFile::isEmpty)) {
-            return List.of();
+            );
         }
 
-        List<PerformanceImage> uploaded = new java.util.ArrayList<>();
+        performerRepository.deleteByPerformanceId(performanceId);
+
+        performanceRepository.delete(performance);
+    }
+
+    private String uploadImage(MultipartFile file) {
+        if (file == null || file.isEmpty()) {
+            return null;
+        }
+
         try {
-            IntStream.range(0, files.size())
-                    .forEach(i -> {
-                        String url = fileUploadService.upload(files.get(i), PERFORMANCE_FOLDER);
-                        uploaded.add(PerformanceImage.builder()
-                                .imageUrl(url)
-                                .sortOrder(i + 1)
-                                .build());
-                    });
-            return uploaded;
+            return fileUploadService.upload(file, PERFORMANCE_FOLDER);
         } catch (Exception e) {
-            uploaded.forEach(img -> fileUploadService.delete(img.getImageUrl()));
             throw e;
         }
     }

--- a/src/main/java/team/unibusk/backend/domain/performance/application/command/PerformanceCommandService.java
+++ b/src/main/java/team/unibusk/backend/domain/performance/application/command/PerformanceCommandService.java
@@ -134,9 +134,10 @@ public class PerformanceCommandService {
 
         if (newImageUrl != null) {
             PerformanceImage oldImage = performanceImageRepository.findByPerformanceId(performance.getId());
-            String deleteTargetUrl = oldImage.getImageUrl();
-
-            performanceImageRepository.deleteByPerformanceId(performance.getId());
+            String deleteTargetUrl = oldImage != null ? oldImage.getImageUrl() : null;
+            if(oldImage != null) {
+                performanceImageRepository.deleteByPerformanceId(performance.getId());
+            }
 
             PerformanceImage newImage = PerformanceImage.builder()
                     .performanceId(performance.getId())
@@ -150,7 +151,9 @@ public class PerformanceCommandService {
                     new TransactionSynchronization() {
                         @Override
                         public void afterCommit() {
-                            fileUploadService.delete(deleteTargetUrl);
+                            if(deleteTargetUrl != null) {
+                                fileUploadService.delete(deleteTargetUrl);
+                            }
                         }
 
                         @Override

--- a/src/main/java/team/unibusk/backend/domain/performance/application/dto/request/PerformanceRegisterServiceRequest.java
+++ b/src/main/java/team/unibusk/backend/domain/performance/application/dto/request/PerformanceRegisterServiceRequest.java
@@ -17,7 +17,7 @@ public record PerformanceRegisterServiceRequest(
         LocalDateTime startTime,
         LocalDateTime endTime,
         String summary,
-        List<MultipartFile> images,
+        MultipartFile image,
         String description
 ) {
     @Builder

--- a/src/main/java/team/unibusk/backend/domain/performance/application/dto/request/PerformanceUpdateServiceRequest.java
+++ b/src/main/java/team/unibusk/backend/domain/performance/application/dto/request/PerformanceUpdateServiceRequest.java
@@ -18,6 +18,6 @@ public record PerformanceUpdateServiceRequest(
         LocalDateTime startTime,
         LocalDateTime endTime,
         String summary,
-        List<MultipartFile> images,
+        MultipartFile image,
         String description
 ) {}

--- a/src/main/java/team/unibusk/backend/domain/performance/application/dto/response/MyPerformanceSummaryResponse.java
+++ b/src/main/java/team/unibusk/backend/domain/performance/application/dto/response/MyPerformanceSummaryResponse.java
@@ -32,16 +32,17 @@ public record MyPerformanceSummaryResponse(
         String performanceLocationName,
 
         @Schema(
-                description = "공연 이미지 URL 리스트",
-                example = "[\"https://image1.jpg\", \"https://image2.jpg\"]"
+                description = "공연 이미지 URL",
+                example = "https://image1.jpg"
         )
-        List<String> imageUrls
+        String imageUrl
 
 ) {
 
     public static MyPerformanceSummaryResponse from(
             Performance performance,
-            PerformanceLocation performanceLocation
+            PerformanceLocation performanceLocation,
+            String imageUrl
     ) {
         return MyPerformanceSummaryResponse.builder()
                 .performanceId(performance.getId())
@@ -50,11 +51,7 @@ public record MyPerformanceSummaryResponse(
                 .startTime(performance.getStartTime())
                 .endTime(performance.getEndTime())
                 .performanceLocationName(performanceLocation.getName())
-                .imageUrls(
-                        performance.getImages().stream()
-                                .map(PerformanceImage::getImageUrl)
-                                .toList()
-                )
+                .imageUrl(imageUrl)
                 .build();
     }
 

--- a/src/main/java/team/unibusk/backend/domain/performance/application/dto/response/PerformanceCursorResponse.java
+++ b/src/main/java/team/unibusk/backend/domain/performance/application/dto/response/PerformanceCursorResponse.java
@@ -3,11 +3,9 @@ package team.unibusk.backend.domain.performance.application.dto.response;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import team.unibusk.backend.domain.performance.domain.Performance;
-import team.unibusk.backend.domain.performance.domain.PerformanceImage;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.List;
 
 @Builder
 public record PerformanceCursorResponse(
@@ -29,7 +27,7 @@ public record PerformanceCursorResponse(
 
         @Schema(
                 description = "공연 이미지 URL",
-                example = "https://unibusk-bucket.s3.ap-northeast-2.amazonaws.com/performance/123e4567.jpg"
+                example = "https://image1.jpg"
         )
         String imageUrl
 

--- a/src/main/java/team/unibusk/backend/domain/performance/application/dto/response/PerformanceCursorResponse.java
+++ b/src/main/java/team/unibusk/backend/domain/performance/application/dto/response/PerformanceCursorResponse.java
@@ -28,25 +28,21 @@ public record PerformanceCursorResponse(
         LocalDateTime endTime,
 
         @Schema(
-                description = "공연 이미지 URL 목록",
-                example = "[\"https://unibusk-bucket.s3.ap-northeast-2.amazonaws.com/performance/123e4567.jpg\"]"
+                description = "공연 이미지 URL",
+                example = "https://unibusk-bucket.s3.ap-northeast-2.amazonaws.com/performance/123e4567.jpg"
         )
-        List<String> images
+        String imageUrl
 
 ) {
 
-    public static PerformanceCursorResponse from(Performance performance) {
+    public static PerformanceCursorResponse from(Performance performance, String imageUrl) {
         return PerformanceCursorResponse.builder()
                 .performanceId(performance.getId())
                 .title(performance.getTitle())
                 .performanceDate(performance.getPerformanceDate())
                 .startTime(performance.getStartTime())
                 .endTime(performance.getEndTime())
-                .images(
-                        performance.getImages().stream()
-                                .map(PerformanceImage::getImageUrl)
-                                .toList()
-                )
+                .imageUrl(imageUrl)
                 .build();
     }
 

--- a/src/main/java/team/unibusk/backend/domain/performance/application/dto/response/PerformanceDetailResponse.java
+++ b/src/main/java/team/unibusk/backend/domain/performance/application/dto/response/PerformanceDetailResponse.java
@@ -3,7 +3,6 @@ package team.unibusk.backend.domain.performance.application.dto.response;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import team.unibusk.backend.domain.performance.domain.Performance;
-import team.unibusk.backend.domain.performance.domain.PerformanceImage;
 import team.unibusk.backend.domain.performance.domain.Performer;
 import team.unibusk.backend.domain.performanceLocation.domain.PerformanceLocation;
 
@@ -40,7 +39,7 @@ public record PerformanceDetailResponse (
 
         @Schema(
                 description = "공연 이미지 URL",
-                example = "https://unibusk-bucket.s3.ap-northeast-2.amazonaws.com/performance/123e4567.jpg"
+                example = "https://image1.jpg"
         )
         String imageUrl,
 

--- a/src/main/java/team/unibusk/backend/domain/performance/application/dto/response/PerformanceDetailResponse.java
+++ b/src/main/java/team/unibusk/backend/domain/performance/application/dto/response/PerformanceDetailResponse.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import team.unibusk.backend.domain.performance.domain.Performance;
 import team.unibusk.backend.domain.performance.domain.PerformanceImage;
+import team.unibusk.backend.domain.performance.domain.Performer;
 import team.unibusk.backend.domain.performanceLocation.domain.PerformanceLocation;
 
 import java.time.LocalDate;
@@ -38,10 +39,10 @@ public record PerformanceDetailResponse (
         String description,
 
         @Schema(
-                description = "공연 이미지 URL 목록",
-                example = "[\"https://unibusk-bucket.s3.ap-northeast-2.amazonaws.com/performance/123e4567.jpg\"]"
+                description = "공연 이미지 URL",
+                example = "https://unibusk-bucket.s3.ap-northeast-2.amazonaws.com/performance/123e4567.jpg"
         )
-        List<String> images,
+        String image,
 
         @Schema(description = "공연자 정보 목록")
         List<PerformerResponse> performers,
@@ -61,7 +62,9 @@ public record PerformanceDetailResponse (
 ){
         public static PerformanceDetailResponse from(
                 Performance performance,
-                PerformanceLocation location
+                PerformanceLocation location,
+                String imageUrl,
+                List<Performer> performers
         ) {
                 return PerformanceDetailResponse.builder()
                         .memberId(performance.getMemberId())
@@ -78,13 +81,9 @@ public record PerformanceDetailResponse (
                         .longitude(location.getLongitude())
                         .summary(performance.getSummary())
                         .description(performance.getDescription())
-                        .images(
-                                performance.getImages().stream()
-                                        .map(PerformanceImage::getImageUrl)
-                                        .toList()
-                        )
+                        .image(imageUrl)
                         .performers(
-                                performance.getPerformers().stream()
+                                performers.stream()
                                         .map(PerformerResponse::from)
                                         .toList()
                         )

--- a/src/main/java/team/unibusk/backend/domain/performance/application/dto/response/PerformanceDetailResponse.java
+++ b/src/main/java/team/unibusk/backend/domain/performance/application/dto/response/PerformanceDetailResponse.java
@@ -42,7 +42,7 @@ public record PerformanceDetailResponse (
                 description = "공연 이미지 URL",
                 example = "https://unibusk-bucket.s3.ap-northeast-2.amazonaws.com/performance/123e4567.jpg"
         )
-        String image,
+        String imageUrl,
 
         @Schema(description = "공연자 정보 목록")
         List<PerformerResponse> performers,
@@ -81,7 +81,7 @@ public record PerformanceDetailResponse (
                         .longitude(location.getLongitude())
                         .summary(performance.getSummary())
                         .description(performance.getDescription())
-                        .image(imageUrl)
+                        .imageUrl(imageUrl)
                         .performers(
                                 performers.stream()
                                         .map(PerformerResponse::from)

--- a/src/main/java/team/unibusk/backend/domain/performance/application/dto/response/PerformancePreviewResponse.java
+++ b/src/main/java/team/unibusk/backend/domain/performance/application/dto/response/PerformancePreviewResponse.java
@@ -32,16 +32,17 @@ public record PerformancePreviewResponse(
         String locationName,
 
         @Schema(
-                description = "공연 이미지 URL 목록",
-                example = "[\"https://unibusk-bucket.s3.ap-northeast-2.amazonaws.com/performance/123e4567.jpg\"]"
+                description = "공연 이미지 URL",
+                example = "https://unibusk-bucket.s3.ap-northeast-2.amazonaws.com/performance/123e4567.jpg"
         )
-        List<String> images
+        String imageUrl
 
 ) {
 
     public static PerformancePreviewResponse from(
             Performance performance,
-            Map<Long, String> locationNameMap
+            Map<Long, String> locationNameMap,
+            String imageUrl
     ) {
         return PerformancePreviewResponse.builder()
                 .performanceId(performance.getId())
@@ -55,11 +56,7 @@ public record PerformancePreviewResponse(
                                 "공연 장소 정보가 없습니다."
                         )
                 )
-                .images(
-                        performance.getImages().stream()
-                                .map(PerformanceImage::getImageUrl)
-                                .toList()
-                )
+                .imageUrl(imageUrl)
                 .build();
     }
 

--- a/src/main/java/team/unibusk/backend/domain/performance/application/dto/response/PerformancePreviewResponse.java
+++ b/src/main/java/team/unibusk/backend/domain/performance/application/dto/response/PerformancePreviewResponse.java
@@ -3,11 +3,9 @@ package team.unibusk.backend.domain.performance.application.dto.response;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import team.unibusk.backend.domain.performance.domain.Performance;
-import team.unibusk.backend.domain.performance.domain.PerformanceImage;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.List;
 import java.util.Map;
 
 @Builder
@@ -33,7 +31,7 @@ public record PerformancePreviewResponse(
 
         @Schema(
                 description = "공연 이미지 URL",
-                example = "https://unibusk-bucket.s3.ap-northeast-2.amazonaws.com/performance/123e4567.jpg"
+                example = "https://image1.jpg"
         )
         String imageUrl
 

--- a/src/main/java/team/unibusk/backend/domain/performance/application/dto/response/PerformanceResponse.java
+++ b/src/main/java/team/unibusk/backend/domain/performance/application/dto/response/PerformanceResponse.java
@@ -33,37 +33,21 @@ public record PerformanceResponse(
         String locationName,
 
         @Schema(
-                description = "공연 이미지 URL 목록",
-                example = "[\"https://unibusk-bucket.s3.ap-northeast-2.amazonaws.com/performance/123e4567.jpg\"]"
+                description = "공연 이미지 URL",
+                example = "https://unibusk-bucket.s3.ap-northeast-2.amazonaws.com/performance/123e4567.jpg"
         )
-        List<String> images
+        String imageUrl
 
 ) {
 
         @QueryProjection
-        public PerformanceResponse(
-                Long performanceId,
-                String title,
-                LocalDate performanceDate,
-                LocalDateTime startTime,
-                LocalDateTime endTime,
-                String locationName,
-                String imageUrl
-        ) {
-                this(
-                        performanceId,
-                        title,
-                        performanceDate,
-                        startTime,
-                        endTime,
-                        locationName,
-                        imageUrl != null ? List.of(imageUrl) : Collections.emptyList()
-                );
+        public PerformanceResponse {
         }
 
         public static PerformanceResponse from(
                 Performance performance,
-                String locationName
+                String locationName,
+                String imageUrl
         ) {
                 return PerformanceResponse.builder()
                         .performanceId(performance.getId())
@@ -72,11 +56,7 @@ public record PerformanceResponse(
                         .startTime(performance.getStartTime())
                         .endTime(performance.getEndTime())
                         .locationName(locationName)
-                        .images(
-                                performance.getImages().stream()
-                                        .map(PerformanceImage::getImageUrl)
-                                        .toList()
-                        )
+                        .imageUrl(imageUrl)
                         .build();
         }
 

--- a/src/main/java/team/unibusk/backend/domain/performance/application/dto/response/PerformanceResponse.java
+++ b/src/main/java/team/unibusk/backend/domain/performance/application/dto/response/PerformanceResponse.java
@@ -4,12 +4,9 @@ import com.querydsl.core.annotations.QueryProjection;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import team.unibusk.backend.domain.performance.domain.Performance;
-import team.unibusk.backend.domain.performance.domain.PerformanceImage;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Collections;
 
 @Builder
 public record PerformanceResponse(
@@ -34,7 +31,7 @@ public record PerformanceResponse(
 
         @Schema(
                 description = "공연 이미지 URL",
-                example = "https://unibusk-bucket.s3.ap-northeast-2.amazonaws.com/performance/123e4567.jpg"
+                example = "https://image1.jpg"
         )
         String imageUrl
 

--- a/src/main/java/team/unibusk/backend/domain/performance/application/query/PerformanceQueryService.java
+++ b/src/main/java/team/unibusk/backend/domain/performance/application/query/PerformanceQueryService.java
@@ -77,7 +77,7 @@ public class PerformanceQueryService {
 
         List<Performer> performers = performerRepository.findByPerformanceId(performanceId);
         PerformanceImage image = performanceImageRepository.findByPerformanceId(performanceId);
-        String imageUrl = image.getImageUrl();
+        String imageUrl = (image != null) ? image.getImageUrl() : null;
 
         return PerformanceDetailResponse.from(performance, location, imageUrl, performers);
     }

--- a/src/main/java/team/unibusk/backend/domain/performance/application/query/PerformanceQueryService.java
+++ b/src/main/java/team/unibusk/backend/domain/performance/application/query/PerformanceQueryService.java
@@ -7,15 +7,14 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import team.unibusk.backend.domain.performance.application.dto.response.*;
-import team.unibusk.backend.domain.performance.domain.Performance;
-import team.unibusk.backend.domain.performance.domain.PerformanceRepository;
-import team.unibusk.backend.domain.performance.domain.PerformanceStatus;
+import team.unibusk.backend.domain.performance.domain.*;
 import team.unibusk.backend.domain.performanceLocation.domain.PerformanceLocation;
 import team.unibusk.backend.domain.performanceLocation.domain.PerformanceLocationRepository;
 import team.unibusk.backend.global.response.CursorResponse;
 import team.unibusk.backend.global.response.PageResponse;
 
 import java.time.LocalDateTime;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -29,10 +28,11 @@ public class PerformanceQueryService {
 
     private final PerformanceRepository performanceRepository;
     private final PerformanceLocationRepository performanceLocationRepository;
+    private final PerformanceImageRepository performanceImageRepository;
+    private final PerformerRepository performerRepository;
 
     public PageResponse<PerformanceResponse> getUpcomingPerformances(Pageable pageable) {
         LocalDateTime now = LocalDateTime.now();
-
         Page<Performance> performances =
                 performanceRepository.findUpcomingPerformances(now, pageable);
 
@@ -41,9 +41,7 @@ public class PerformanceQueryService {
 
     public List<PerformancePreviewResponse> getUpcomingPerformancesPreview() {
         LocalDateTime now = LocalDateTime.now();
-
         Pageable pageable = PageRequest.of(0, 8);
-
         List<Performance> performances = performanceRepository.findUpcomingPreview(now, pageable);
 
         Set<Long> locationIds = performances.stream()
@@ -57,14 +55,15 @@ public class PerformanceQueryService {
                                 PerformanceLocation::getName
                         ));
 
+        Map<Long, String> imageUrlMap = getImageUrlMap(performances);
+
         return performances.stream()
-                .map(p -> PerformancePreviewResponse.from(p, locationNameMap))
+                .map(p -> PerformancePreviewResponse.from(p, locationNameMap, imageUrlMap.get(p.getId())))
                 .toList();
     }
 
     public PageResponse<PerformanceResponse> getPastPerformances(Pageable pageable) {
         LocalDateTime now = LocalDateTime.now();
-
         Page<Performance> performances =
                 performanceRepository.findPastPerformances(now, pageable);
 
@@ -73,11 +72,14 @@ public class PerformanceQueryService {
 
     public PerformanceDetailResponse getPerformanceDetail(Long performanceId) {
         Performance performance = performanceRepository.findDetailById(performanceId);
-
         PerformanceLocation location =
                 performanceLocationRepository.findById(performance.getPerformanceLocationId());
 
-        return PerformanceDetailResponse.from(performance, location);
+        List<Performer> performers = performerRepository.findByPerformanceId(performanceId);
+        PerformanceImage image = performanceImageRepository.findByPerformanceId(performanceId);
+        String imageUrl = image.getImageUrl();
+
+        return PerformanceDetailResponse.from(performance, location, imageUrl, performers);
     }
 
     public PageResponse<PerformanceResponse> searchPerformances(
@@ -154,12 +156,15 @@ public class PerformanceQueryService {
                                 Function.identity()
                         ));
 
+        Map<Long, String> imageUrlMap = getImageUrlMap(performances);
+
         List<MyPerformanceSummaryResponse> content =
                 performances.stream()
                         .map(p ->
                                 MyPerformanceSummaryResponse.from(
                                         p,
-                                        locationMap.get(p.getPerformanceLocationId())
+                                        locationMap.get(p.getPerformanceLocationId()),
+                                        imageUrlMap.get(p.getId())
                                 )
                         )
                         .toList();
@@ -177,16 +182,17 @@ public class PerformanceQueryService {
     }
 
     private PageResponse<PerformanceResponse> mapToPageResponse(Page<Performance> performances) {
-        Map<Long, String> locationNameMap =
-                performanceLocationRepository.findByIds(
-                                performances.getContent().stream()
-                                        .map(Performance::getPerformanceLocationId)
-                                        .collect(Collectors.toSet())
-                        ).stream()
-                        .collect(Collectors.toMap(
-                                PerformanceLocation::getId,
-                                PerformanceLocation::getName
-                        ));
+        Set<Long> locationIds = performances.getContent().stream()
+                .map(Performance::getPerformanceLocationId)
+                .collect(Collectors.toSet());
+
+        Map<Long, String> locationNameMap = performanceLocationRepository.findByIds(locationIds).stream()
+                .collect(Collectors.toMap(
+                        PerformanceLocation::getId,
+                        PerformanceLocation::getName
+                ));
+
+        Map<Long, String> imageUrlMap = getImageUrlMap(performances.getContent());
 
         Page<PerformanceResponse> page = performances.map(p ->
                 PerformanceResponse.from(
@@ -194,7 +200,8 @@ public class PerformanceQueryService {
                         locationNameMap.getOrDefault(
                                 p.getPerformanceLocationId(),
                                 "공연 장소 정보가 없습니다."
-                        )
+                        ),
+                        imageUrlMap.get(p.getId())
                 )
         );
 
@@ -208,9 +215,11 @@ public class PerformanceQueryService {
             performances.remove(size);
         }
 
+        Map<Long, String> imageUrlMap = getImageUrlMap(performances);
+
         List<PerformanceCursorResponse> contents =
                 performances.stream()
-                        .map(PerformanceCursorResponse::from)
+                        .map(p -> PerformanceCursorResponse.from(p, imageUrlMap.get(p.getId())))
                         .toList();
 
         LocalDateTime nextCursorTime = null;
@@ -228,6 +237,24 @@ public class PerformanceQueryService {
                 nextCursorId,
                 hasNext
         );
+    }
+
+    private Map<Long, String> getImageUrlMap(List<Performance> performances) {
+        if (performances.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
+        List<Long> performanceIds = performances.stream()
+                .map(Performance::getId)
+                .toList();
+
+        List<PerformanceImage> images = performanceImageRepository.findByPerformanceIdIn(performanceIds);
+
+        return images.stream()
+                .collect(Collectors.toMap(
+                        PerformanceImage::getPerformanceId,
+                        PerformanceImage::getImageUrl
+                ));
     }
 
 }

--- a/src/main/java/team/unibusk/backend/domain/performance/application/query/PerformanceQueryService.java
+++ b/src/main/java/team/unibusk/backend/domain/performance/application/query/PerformanceQueryService.java
@@ -253,7 +253,8 @@ public class PerformanceQueryService {
         return images.stream()
                 .collect(Collectors.toMap(
                         PerformanceImage::getPerformanceId,
-                        PerformanceImage::getImageUrl
+                        PerformanceImage::getImageUrl,
+                        (existing, replacement) -> existing
                 ));
     }
 

--- a/src/main/java/team/unibusk/backend/domain/performance/domain/Performance.java
+++ b/src/main/java/team/unibusk/backend/domain/performance/domain/Performance.java
@@ -5,7 +5,6 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.BatchSize;
 import team.unibusk.backend.domain.performance.presentation.exception.PerformanceAccessDeniedException;
 import team.unibusk.backend.global.domain.BaseTimeEntity;
 

--- a/src/main/java/team/unibusk/backend/domain/performance/domain/Performance.java
+++ b/src/main/java/team/unibusk/backend/domain/performance/domain/Performance.java
@@ -13,9 +13,9 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.*;
 
-@Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
 public class Performance extends BaseTimeEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -48,22 +48,10 @@ public class Performance extends BaseTimeEntity {
     @Column(nullable = false)
     private long viewCount = 0L;
 
-    // 애그리거트 루트를 통해서만 자식의 생명주기가 관리됨
-    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
-    @JoinColumn(name = "performance_id") // 자식 테이블에 FK 생성
-    @BatchSize(size = 10)
-    private List<PerformanceImage> images = new ArrayList<>();
-
-    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
-    @JoinColumn(name = "performance_id")
-    @BatchSize(size = 10)
-    private List<Performer> performers = new ArrayList<>();
-
     @Builder
     private Performance(Long memberId, Long performanceLocationId, String title,
                         String summary, String description, LocalDate performanceDate,
-                        LocalDateTime startTime, LocalDateTime endTime,
-                        List<PerformanceImage> images, List<Performer> performers) {
+                        LocalDateTime startTime, LocalDateTime endTime) {
         this.memberId = memberId;
         this.performanceLocationId = performanceLocationId;
         this.title = title;
@@ -73,9 +61,6 @@ public class Performance extends BaseTimeEntity {
         this.startTime = startTime;
         this.endTime = endTime;
         this.viewCount = 0;
-
-        if (images != null) this.images.addAll(images);
-        if (performers != null) this.performers.addAll(performers);
     }
 
     public void updateBasicInfo(
@@ -94,22 +79,6 @@ public class Performance extends BaseTimeEntity {
         this.summary = summary;
         this.description = description;
         this.performanceLocationId = performanceLocationId;
-    }
-
-    public void addPerformer(Performer performer) {
-        this.performers.add(performer);
-    }
-
-    public void addImage(PerformanceImage image) {
-        this.images.add(image);
-    }
-
-    public void clearPerformers() {
-        this.performers.clear();
-    }
-
-    public void clearImages() {
-        this.images.clear();
     }
 
     public void validateOwner(Long memberId) {

--- a/src/main/java/team/unibusk/backend/domain/performance/domain/PerformanceImage.java
+++ b/src/main/java/team/unibusk/backend/domain/performance/domain/PerformanceImage.java
@@ -16,18 +16,16 @@ public class PerformanceImage extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "performance_id", insertable = false, updatable = false)
+    @Column(name = "performance_id")
     private Long performanceId;
 
     @Column(nullable = false, length = 512)
     private String imageUrl;
 
-    @Column(nullable = false)
-    private int sortOrder;
-
     @Builder
-    private PerformanceImage(String imageUrl, int sortOrder) {
+    private PerformanceImage(Long performanceId, String imageUrl) {
+        this.performanceId = performanceId;
         this.imageUrl = imageUrl;
-        this.sortOrder = sortOrder;
     }
+
 }

--- a/src/main/java/team/unibusk/backend/domain/performance/domain/PerformanceImage.java
+++ b/src/main/java/team/unibusk/backend/domain/performance/domain/PerformanceImage.java
@@ -16,7 +16,7 @@ public class PerformanceImage extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "performance_id")
+    @Column(name = "performance_id", nullable = false, unique = true)
     private Long performanceId;
 
     @Column(nullable = false, length = 512)

--- a/src/main/java/team/unibusk/backend/domain/performance/domain/PerformanceImageRepository.java
+++ b/src/main/java/team/unibusk/backend/domain/performance/domain/PerformanceImageRepository.java
@@ -1,0 +1,15 @@
+package team.unibusk.backend.domain.performance.domain;
+
+import java.util.List;
+
+public interface PerformanceImageRepository {
+
+    void deleteByPerformanceId(Long performanceId);
+
+    PerformanceImage save(PerformanceImage performanceImage);
+
+    PerformanceImage findByPerformanceId(Long performanceId);
+
+    List<PerformanceImage> findByPerformanceIdIn(List<Long> performanceIds);
+
+}

--- a/src/main/java/team/unibusk/backend/domain/performance/domain/PerformanceRepository.java
+++ b/src/main/java/team/unibusk/backend/domain/performance/domain/PerformanceRepository.java
@@ -11,7 +11,7 @@ import java.util.Optional;
 
 public interface PerformanceRepository {
 
-    Performance save(Performance perfomance);
+    Performance save(Performance performance);
 
     Page<Performance> findPastPerformances(LocalDateTime now, Pageable pageable);
 

--- a/src/main/java/team/unibusk/backend/domain/performance/domain/PerformanceRepository.java
+++ b/src/main/java/team/unibusk/backend/domain/performance/domain/PerformanceRepository.java
@@ -4,10 +4,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import team.unibusk.backend.domain.performance.application.dto.response.PerformanceResponse;
 
-import javax.swing.text.html.Option;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
 
 public interface PerformanceRepository {
 

--- a/src/main/java/team/unibusk/backend/domain/performance/domain/Performer.java
+++ b/src/main/java/team/unibusk/backend/domain/performance/domain/Performer.java
@@ -6,9 +6,9 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
 public class Performer {
 
     @Id

--- a/src/main/java/team/unibusk/backend/domain/performance/domain/Performer.java
+++ b/src/main/java/team/unibusk/backend/domain/performance/domain/Performer.java
@@ -15,6 +15,9 @@ public class Performer {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(name = "performance_id", nullable = false)
+    private Long performanceId;
+
     @Column(nullable = false, length = 20)
     private String name;
 
@@ -28,7 +31,8 @@ public class Performer {
     private String instagram;
 
     @Builder
-    private Performer(String name, String email, String phoneNumber, String instagram) {
+    private Performer(Long performanceId, String name, String email, String phoneNumber, String instagram) {
+        this.performanceId = performanceId;
         this.name = name;
         this.email = email;
         this.phoneNumber = phoneNumber;

--- a/src/main/java/team/unibusk/backend/domain/performance/domain/PerformerRepository.java
+++ b/src/main/java/team/unibusk/backend/domain/performance/domain/PerformerRepository.java
@@ -1,0 +1,13 @@
+package team.unibusk.backend.domain.performance.domain;
+
+import java.util.List;
+
+public interface PerformerRepository {
+
+    void deleteByPerformanceId(Long performanceId);
+
+    List<Performer> saveAll(List<Performer> performers);
+
+    List<Performer> findByPerformanceId(Long performanceId);
+
+}

--- a/src/main/java/team/unibusk/backend/domain/performance/infrastructure/PerformanceImageJpaRepository.java
+++ b/src/main/java/team/unibusk/backend/domain/performance/infrastructure/PerformanceImageJpaRepository.java
@@ -1,0 +1,16 @@
+package team.unibusk.backend.domain.performance.infrastructure;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import team.unibusk.backend.domain.performance.domain.PerformanceImage;
+
+import java.util.List;
+
+public interface PerformanceImageJpaRepository extends JpaRepository<PerformanceImage, Long> {
+
+    void deleteByPerformanceId(Long performanceId);
+
+    PerformanceImage findByPerformanceId(Long performanceId);
+
+    List<PerformanceImage> findByPerformanceIdIn(List<Long> performanceIds);
+
+}

--- a/src/main/java/team/unibusk/backend/domain/performance/infrastructure/PerformanceImageRepositoryImpl.java
+++ b/src/main/java/team/unibusk/backend/domain/performance/infrastructure/PerformanceImageRepositoryImpl.java
@@ -1,0 +1,36 @@
+package team.unibusk.backend.domain.performance.infrastructure;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import team.unibusk.backend.domain.performance.domain.PerformanceImage;
+import team.unibusk.backend.domain.performance.domain.PerformanceImageRepository;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Repository
+public class PerformanceImageRepositoryImpl implements PerformanceImageRepository {
+
+    private final PerformanceImageJpaRepository performanceImageJpaRepository;
+
+    @Override
+    public void deleteByPerformanceId(Long performanceId) {
+        performanceImageJpaRepository.deleteByPerformanceId(performanceId);
+    }
+
+    @Override
+    public PerformanceImage save(PerformanceImage performanceImage) {
+        return performanceImageJpaRepository.save(performanceImage);
+    }
+
+    @Override
+    public PerformanceImage findByPerformanceId(Long performanceId) {
+        return performanceImageJpaRepository.findByPerformanceId(performanceId);
+    }
+
+    @Override
+    public List<PerformanceImage> findByPerformanceIdIn(List<Long> performanceIds) {
+        return performanceImageJpaRepository.findByPerformanceIdIn(performanceIds);
+    }
+
+}

--- a/src/main/java/team/unibusk/backend/domain/performance/infrastructure/PerformanceJpaRepository.java
+++ b/src/main/java/team/unibusk/backend/domain/performance/infrastructure/PerformanceJpaRepository.java
@@ -15,7 +15,7 @@ public interface PerformanceJpaRepository extends JpaRepository<Performance, Lon
 
     @Query(
         value = """
-            select distinct p
+            select p
             from Performance p
             where p.endTime < :now
             order by p.startTime desc
@@ -30,7 +30,7 @@ public interface PerformanceJpaRepository extends JpaRepository<Performance, Lon
 
     @Query(
         value = """
-            select distinct p
+            select p
             from Performance p
             where p.endTime >= :now
             order by p.startTime asc
@@ -44,19 +44,13 @@ public interface PerformanceJpaRepository extends JpaRepository<Performance, Lon
     Page<Performance> findUpcomingPerformances(@Param("now") LocalDateTime now, Pageable pageable);
 
     @Query("""
-        select distinct p
+        select p
         from Performance p
         where p.endTime >= :now
         order by p.startTime asc
     """)
     List<Performance> findUpcomingPreview(@Param("now") LocalDateTime now, Pageable pageable);
 
-    @Query("""
-        select distinct p
-        from Performance p
-        left join fetch p.images
-        where p.id = :performanceId
-    """)
     Optional<Performance> findDetailById(@Param("performanceId") Long performanceId);
 
 }

--- a/src/main/java/team/unibusk/backend/domain/performance/infrastructure/PerformanceJpaRepository.java
+++ b/src/main/java/team/unibusk/backend/domain/performance/infrastructure/PerformanceJpaRepository.java
@@ -51,6 +51,11 @@ public interface PerformanceJpaRepository extends JpaRepository<Performance, Lon
     """)
     List<Performance> findUpcomingPreview(@Param("now") LocalDateTime now, Pageable pageable);
 
+    @Query("""
+        select p
+        from Performance p
+        where p.id = :performanceId
+    """)
     Optional<Performance> findDetailById(@Param("performanceId") Long performanceId);
 
 }

--- a/src/main/java/team/unibusk/backend/domain/performance/infrastructure/PerformanceQueryDslRepository.java
+++ b/src/main/java/team/unibusk/backend/domain/performance/infrastructure/PerformanceQueryDslRepository.java
@@ -118,12 +118,9 @@ public class PerformanceQueryDslRepository {
             int size
     ) {
         QPerformance p = QPerformance.performance;
-        QPerformanceImage i = QPerformanceImage.performanceImage;
 
         return queryFactory
-                .selectDistinct(p)
-                .from(p)
-                .leftJoin(p.images, i).fetchJoin()
+                .selectFrom(p)
                 .where(
                         p.memberId.eq(memberId),
                         cursorIdLt(p, cursorId)

--- a/src/main/java/team/unibusk/backend/domain/performance/infrastructure/PerformanceQueryDslRepository.java
+++ b/src/main/java/team/unibusk/backend/domain/performance/infrastructure/PerformanceQueryDslRepository.java
@@ -16,7 +16,6 @@ import team.unibusk.backend.domain.performance.application.dto.response.QPerform
 import team.unibusk.backend.domain.performance.domain.Performance;
 import team.unibusk.backend.domain.performance.domain.PerformanceStatus;
 import team.unibusk.backend.domain.performance.domain.QPerformance;
-import team.unibusk.backend.domain.performance.domain.QPerformanceImage;
 
 import static team.unibusk.backend.domain.performance.domain.QPerformance.performance;
 import static team.unibusk.backend.domain.performance.domain.QPerformanceImage.performanceImage;

--- a/src/main/java/team/unibusk/backend/domain/performance/infrastructure/PerformanceRepositoryImpl.java
+++ b/src/main/java/team/unibusk/backend/domain/performance/infrastructure/PerformanceRepositoryImpl.java
@@ -13,8 +13,8 @@ import team.unibusk.backend.domain.performance.presentation.exception.Performanc
 import java.time.LocalDateTime;
 import java.util.List;
 
-@Repository
 @RequiredArgsConstructor
+@Repository
 public class PerformanceRepositoryImpl implements PerformanceRepository {
 
     private final PerformanceJpaRepository performanceJpaRepository;

--- a/src/main/java/team/unibusk/backend/domain/performance/infrastructure/PerformerJpaRepository.java
+++ b/src/main/java/team/unibusk/backend/domain/performance/infrastructure/PerformerJpaRepository.java
@@ -1,0 +1,14 @@
+package team.unibusk.backend.domain.performance.infrastructure;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import team.unibusk.backend.domain.performance.domain.Performer;
+
+import java.util.List;
+
+public interface PerformerJpaRepository extends JpaRepository<Performer, Long> {
+
+    void deleteByPerformanceId(Long performanceId);
+
+    List<Performer> findByPerformanceId(Long performanceId);
+
+}

--- a/src/main/java/team/unibusk/backend/domain/performance/infrastructure/PerformerRepositoryImpl.java
+++ b/src/main/java/team/unibusk/backend/domain/performance/infrastructure/PerformerRepositoryImpl.java
@@ -1,0 +1,31 @@
+package team.unibusk.backend.domain.performance.infrastructure;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import team.unibusk.backend.domain.performance.domain.Performer;
+import team.unibusk.backend.domain.performance.domain.PerformerRepository;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Repository
+public class PerformerRepositoryImpl implements PerformerRepository {
+
+    private final PerformerJpaRepository performerJpaRepository;
+
+    @Override
+    public void deleteByPerformanceId(Long performanceId) {
+        performerJpaRepository.deleteByPerformanceId(performanceId);
+    }
+
+    @Override
+    public List<Performer> saveAll(List<Performer> performers) {
+        return performerJpaRepository.saveAll(performers);
+    }
+
+    @Override
+    public List<Performer> findByPerformanceId(Long performanceId) {
+        return performerJpaRepository.findByPerformanceId(performanceId);
+    }
+
+}

--- a/src/main/java/team/unibusk/backend/domain/performance/presentation/command/PerformanceCommandController.java
+++ b/src/main/java/team/unibusk/backend/domain/performance/presentation/command/PerformanceCommandController.java
@@ -25,11 +25,11 @@ public class PerformanceCommandController implements PerformanceCommandDocsContr
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<PerformanceRegisterResponse> registerPerformance(
             @RequestPart("request") @Valid PerformanceRegisterRequest request,
-            @RequestPart(value = "images", required = false) List<MultipartFile> images,
+            @RequestPart(value = "image", required = false) MultipartFile image,
             @MemberId Long memberId
     ) {
         PerformanceRegisterResponse response =
-                performanceCommandService.register(request.toServiceRequest(memberId, images));
+                performanceCommandService.register(request.toServiceRequest(memberId, image));
 
         return ResponseEntity.status(201).body(response);
     }
@@ -38,10 +38,10 @@ public class PerformanceCommandController implements PerformanceCommandDocsContr
     public ResponseEntity<PerformanceDetailResponse> updatePerformance(
             @PathVariable Long performanceId,
             @RequestPart("request") @Valid PerformanceUpdateRequest request,
-            @RequestPart(value = "images", required = false) List<MultipartFile> images,
+            @RequestPart(value = "image", required = false) MultipartFile image,
             @MemberId Long memberId
     ) {
-        PerformanceDetailResponse response = performanceCommandService.updatePerformance(request.toServiceRequest(performanceId, memberId, images));
+        PerformanceDetailResponse response = performanceCommandService.updatePerformance(request.toServiceRequest(performanceId, memberId, image));
 
         return ResponseEntity.status(200).body(response);
     }

--- a/src/main/java/team/unibusk/backend/domain/performance/presentation/command/PerformanceCommandController.java
+++ b/src/main/java/team/unibusk/backend/domain/performance/presentation/command/PerformanceCommandController.java
@@ -13,8 +13,6 @@ import team.unibusk.backend.domain.performance.presentation.request.PerformanceR
 import team.unibusk.backend.domain.performance.presentation.request.PerformanceUpdateRequest;
 import team.unibusk.backend.global.annotation.MemberId;
 
-import java.util.List;
-
 @RequiredArgsConstructor
 @RequestMapping("/performances")
 @RestController

--- a/src/main/java/team/unibusk/backend/domain/performance/presentation/command/PerformanceCommandDocsController.java
+++ b/src/main/java/team/unibusk/backend/domain/performance/presentation/command/PerformanceCommandDocsController.java
@@ -21,8 +21,6 @@ import team.unibusk.backend.global.annotation.MemberId;
 import team.unibusk.backend.global.annotation.SwaggerBody;
 import team.unibusk.backend.global.exception.ExceptionResponse;
 
-import java.util.List;
-
 @Tag(name = "Performance", description = "공연 관련 API")
 @RequestMapping("/performances")
 public interface PerformanceCommandDocsController {

--- a/src/main/java/team/unibusk/backend/domain/performance/presentation/command/PerformanceCommandDocsController.java
+++ b/src/main/java/team/unibusk/backend/domain/performance/presentation/command/PerformanceCommandDocsController.java
@@ -43,7 +43,7 @@ public interface PerformanceCommandDocsController {
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     ResponseEntity<PerformanceRegisterResponse> registerPerformance(
             @RequestPart("request") @Valid PerformanceRegisterRequest request,
-            @Parameter(description = "공연 관련 이미지 리스트 (다중 파일 업로드 가능)")
+            @Parameter(description = "공연 관련 이미지")
             @RequestPart(value = "image", required = false) MultipartFile image,
             @MemberId Long memberId
     );

--- a/src/main/java/team/unibusk/backend/domain/performance/presentation/command/PerformanceCommandDocsController.java
+++ b/src/main/java/team/unibusk/backend/domain/performance/presentation/command/PerformanceCommandDocsController.java
@@ -46,7 +46,7 @@ public interface PerformanceCommandDocsController {
     ResponseEntity<PerformanceRegisterResponse> registerPerformance(
             @RequestPart("request") @Valid PerformanceRegisterRequest request,
             @Parameter(description = "공연 관련 이미지 리스트 (다중 파일 업로드 가능)")
-            @RequestPart(value = "images", required = false) List<MultipartFile> images,
+            @RequestPart(value = "image", required = false) MultipartFile image,
             @MemberId Long memberId
     );
 
@@ -66,7 +66,7 @@ public interface PerformanceCommandDocsController {
     ResponseEntity<PerformanceDetailResponse> updatePerformance(
             @PathVariable Long performanceId,
             @RequestPart("request") @Valid PerformanceUpdateRequest request,
-            @RequestPart(value = "images", required = false) List<MultipartFile> images,
+            @RequestPart(value = "image", required = false) MultipartFile image,
             @MemberId Long memberId
     );
 

--- a/src/main/java/team/unibusk/backend/domain/performance/presentation/request/PerformanceRegisterRequest.java
+++ b/src/main/java/team/unibusk/backend/domain/performance/presentation/request/PerformanceRegisterRequest.java
@@ -101,8 +101,8 @@ public record PerformanceRegisterRequest (
     }
 
 
-    public PerformanceRegisterServiceRequest toServiceRequest(Long memberId, List<MultipartFile> images) {
-        List<MultipartFile> safeImages = (images == null) ? List.of() : images;
+    public PerformanceRegisterServiceRequest toServiceRequest(Long memberId, MultipartFile image) {
+        MultipartFile safeImage = image;
         return PerformanceRegisterServiceRequest.builder()
                 .performers(this.performers.stream()
                         .map(p -> PerformanceRegisterServiceRequest.PerformerServiceRequest.builder()
@@ -120,7 +120,7 @@ public record PerformanceRegisterRequest (
                 .endTime(this.endTime)
                 .summary(this.summary)
                 .description(this.description)
-                .images(safeImages)
+                .image(safeImage)
                 .build();
     }
 }

--- a/src/main/java/team/unibusk/backend/domain/performance/presentation/request/PerformanceUpdateRequest.java
+++ b/src/main/java/team/unibusk/backend/domain/performance/presentation/request/PerformanceUpdateRequest.java
@@ -50,9 +50,9 @@ public record PerformanceUpdateRequest(
     public PerformanceUpdateServiceRequest toServiceRequest(
             Long performanceId,
             Long memberId,
-            List<MultipartFile> images
+            MultipartFile image
     ) {
-        List<MultipartFile> safeImages = (images == null) ? List.of() : images;
+        MultipartFile safeImage = image;
         return PerformanceUpdateServiceRequest.builder()
                 .memberId(memberId)
                 .performanceId(performanceId)
@@ -63,7 +63,7 @@ public record PerformanceUpdateRequest(
                 .startTime(startTime)
                 .endTime(endTime)
                 .summary(summary)
-                .images(safeImages)
+                .image(safeImage)
                 .description(description)
                 .build();
     }

--- a/src/test/java/team/unibusk/backend/domain/performance/application/query/PerformanceQueryServiceTest.java
+++ b/src/test/java/team/unibusk/backend/domain/performance/application/query/PerformanceQueryServiceTest.java
@@ -8,10 +8,7 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import team.unibusk.backend.domain.performance.application.dto.response.*;
-import team.unibusk.backend.domain.performance.domain.Performance;
-import team.unibusk.backend.domain.performance.domain.PerformanceFixture;
-import team.unibusk.backend.domain.performance.domain.PerformanceRepository;
-import team.unibusk.backend.domain.performance.domain.PerformanceStatus;
+import team.unibusk.backend.domain.performance.domain.*;
 import team.unibusk.backend.domain.performanceLocation.domain.PerformanceLocation;
 import team.unibusk.backend.domain.performanceLocation.domain.PerformanceLocationFixture;
 import team.unibusk.backend.domain.performanceLocation.domain.PerformanceLocationRepository;
@@ -37,6 +34,12 @@ class PerformanceQueryServiceTest extends UnitTestSupport {
 
     @Mock
     private PerformanceRepository performanceRepository;
+
+    @Mock
+    private PerformanceImageRepository performanceImageRepository;
+
+    @Mock
+    private PerformerRepository performerRepository;
 
     @Mock
     private PerformanceLocationRepository performanceLocationRepository;

--- a/src/test/java/team/unibusk/backend/domain/performance/application/query/PerformanceQueryServiceTest.java
+++ b/src/test/java/team/unibusk/backend/domain/performance/application/query/PerformanceQueryServiceTest.java
@@ -26,6 +26,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
 
 class PerformanceQueryServiceTest extends UnitTestSupport {
 
@@ -103,6 +104,17 @@ class PerformanceQueryServiceTest extends UnitTestSupport {
         given(performanceLocationRepository.findByIds(Set.of(10L, 15L)))
                 .willReturn(List.of(location1, location2));
 
+        PerformanceImage img1 = mock(PerformanceImage.class);
+        given(img1.getPerformanceId()).willReturn(2L);
+        given(img1.getImageUrl()).willReturn("preview_image_2.jpg");
+
+        PerformanceImage img2 = mock(PerformanceImage.class);
+        given(img2.getPerformanceId()).willReturn(3L);
+        given(img2.getImageUrl()).willReturn("preview_image_3.jpg");
+
+        given(performanceImageRepository.findByPerformanceIdIn(anyList()))
+                .willReturn(List.of(img1, img2));
+
         List<PerformancePreviewResponse> response = performanceQueryService.getUpcomingPerformancesPreview();
 
         assertThat(response).hasSize(2);
@@ -110,11 +122,12 @@ class PerformanceQueryServiceTest extends UnitTestSupport {
         assertThat(response.get(0).performanceId()).isEqualTo(2L);
         assertThat(response.get(0).title()).isEqualTo("테스트 공연2");
         assertThat(response.get(0).locationName()).isEqualTo("망원");
-
+        assertThat(response.get(0).imageUrl()).isEqualTo("preview_image_2.jpg");
 
         assertThat(response.get(1).performanceId()).isEqualTo(3L);
         assertThat(response.get(1).title()).isEqualTo("테스트 공연3");
         assertThat(response.get(1).locationName()).isEqualTo("신촌");
+        assertThat(response.get(1).imageUrl()).isEqualTo("preview_image_3.jpg");
     }
 
     @Test
@@ -165,22 +178,34 @@ class PerformanceQueryServiceTest extends UnitTestSupport {
         Long locationId = 10L;
 
         Performance performance = PerformanceFixture.createPerformance(performanceId, 100L, locationId, LocalDateTime.now());
-
         given(performanceRepository.findDetailById(eq(performanceId))).willReturn(performance);
 
         PerformanceLocation location = PerformanceLocationFixture.createLocation(locationId, "신촌");
-
         given(performanceLocationRepository.findById(eq(locationId))).willReturn(location);
+
+        PerformanceImage img = mock(PerformanceImage.class);
+        given(img.getImageUrl()).willReturn("image1.jpg");
+        given(performanceImageRepository.findByPerformanceId(performanceId))
+                .willReturn(img);
+
+        Performer performer = mock(Performer.class);
+        given(performer.getName()).willReturn("밴드 유니버스크");
+        given(performerRepository.findByPerformanceId(eq(performanceId)))
+                .willReturn(List.of(performer));
 
         PerformanceDetailResponse response = performanceQueryService.getPerformanceDetail(performanceId);
 
         assertThat(response.performanceId()).isEqualTo(1L);
         assertThat(response.title()).isEqualTo("테스트 공연1");
-
         assertThat(response.locationName()).isEqualTo("신촌");
+
+        assertThat(response.imageUrl()).isEqualTo("image1.jpg");
+        assertThat(response.performers().get(0).name()).isEqualTo("밴드 유니버스크");
 
         then(performanceRepository).should().findDetailById(performanceId);
         then(performanceLocationRepository).should().findById(locationId);
+        then(performanceImageRepository).should().findByPerformanceId(performanceId);
+        then(performerRepository).should().findByPerformanceId(performanceId);
     }
 
     @Test
@@ -248,12 +273,20 @@ class PerformanceQueryServiceTest extends UnitTestSupport {
                 eq(locationId), eq(cursorTime), eq(cursorId), eq(size)
         )).willReturn(mutableList);
 
+        PerformanceImage img = mock(PerformanceImage.class);
+        given(img.getPerformanceId()).willReturn(101L);
+        given(img.getImageUrl()).willReturn("cursor_img_101.jpg");
+
+        given(performanceImageRepository.findByPerformanceIdIn(anyList()))
+                .willReturn(List.of(img));
+
         CursorResponse<PerformanceCursorResponse> response = performanceQueryService.getUpcomingByLocationWithCursor(
                 locationId, cursorTime, cursorId, size
         );
 
         assertThat(response.content()).hasSize(2);
         assertThat(response.content().get(0).performanceId()).isEqualTo(101L);
+        assertThat(response.content().get(0).imageUrl()).isEqualTo("cursor_img_101.jpg");
         assertThat(response.content().get(1).performanceId()).isEqualTo(102L);
 
         assertThat(response.hasNext()).isTrue();
@@ -369,6 +402,13 @@ class PerformanceQueryServiceTest extends UnitTestSupport {
         given(performanceLocationRepository.findByIds(Set.of(10L, 20L)))
                 .willReturn(List.of(loc1, loc2));
 
+        PerformanceImage img = mock(PerformanceImage.class);
+        given(img.getPerformanceId()).willReturn(49L);
+        given(img.getImageUrl()).willReturn("img_49.jpg");
+
+        given(performanceImageRepository.findByPerformanceIdIn(anyList()))
+                .willReturn(List.of(img));
+
         CursorResponse<MyPerformanceSummaryResponse> response =
                 performanceQueryService.getMyPerformances(memberId, cursorId, size);
 
@@ -376,6 +416,7 @@ class PerformanceQueryServiceTest extends UnitTestSupport {
 
         assertThat(response.content().get(0).performanceId()).isEqualTo(49L);
         assertThat(response.content().get(0).performanceLocationName()).isEqualTo("홍대");
+        assertThat(response.content().get(0).imageUrl()).isEqualTo("img_49.jpg");
 
         assertThat(response.content().get(1).performanceId()).isEqualTo(48L);
         assertThat(response.content().get(1).performanceLocationName()).isEqualTo("신촌");


### PR DESCRIPTION
## 관련 이슈
- #227

## Summary

**Performance의 PerformanceImage, Performer 객체 참조를 ID 참조로 변경**

## Tasks

- 공연 이미지 업로드를 단일 파일로 변경
- PerformanceImage 객체 참조를 ID 참조로 변경
- Performer 객체 참조를 ID 참조로 변경


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

Performance 엔티티가 보유하던 자식 엔티티(PerformanceImage, Performer)의 직접 연관관계를 제거하고 ID(성능 ID) 참조 방식으로 전환한 리팩터링입니다. 주요 변경 사항은 다음과 같습니다:

- 이미지 업로드 단순화: 다중 파일 업로드(List<MultipartFile> images) → 단일 파일 업로드(MultipartFile image)로 변경. 서비스 레벨에서 uploadImage(MultipartFile) 사용 및 트랜잭션 동기화(TransactionSynchronization)를 통해 커밋 성공/실패에 따른 파일 삭제 후처리 적용.
- 엔티티 관계 분리: Performance 엔티티에서 images/performers 컬렉션 주입(빌더 파라미터) 및 add/clear 계열 공개 메서드 삭제. PerformanceImage와 Performer는 performanceId 필드로 Performance를 참조하도록 변경(PerformanceImage의 performance_id 컬럼에 nullable=false, unique=true 제약 추가; Performer에 performanceId 컬럼 추가).
- PerformanceImage 구조 변경: sortOrder 필드 제거, 빌더 생성자 시그니처가 (performanceId, imageUrl) 기반으로 변경.
- 리포지토리 분리 및 구현 추가: PerformanceImageRepository, PerformerRepository 도메인 인터페이스와 Spring Data JPA 인터페이스(PerformanceImageJpaRepository, PerformerJpaRepository) 및 구현체(PerformanceImageRepositoryImpl, PerformerRepositoryImpl) 추가. findByPerformanceId, findByPerformanceIdIn, deleteByPerformanceId, saveAll 등 파생 쿼리/메서드 도입.
- 서비스/쿼리 변경:
  - PerformanceCommandService: register/update/delete 로직을 단일 이미지 흐름으로 변경하고 퍼포머 저장/삭제를 performanceId 기반으로 분리함. 업로드된 파일의 삭제 타이밍을 afterCommit/afterCompletion으로 분기 처리.
  - PerformanceQueryService: 응답 생성 시 별도 일괄 조회한 이미지 URL 맵(getImageUrlMap)을 사용해 DTO 생성자에 imageUrl을 전달하도록 변경. 퍼포머도 별도 조회하여 PerformanceDetailResponse에 전달.
- 응답 DTO 표준화: 모든 공연 관련 DTO(PerformanceResponse, PerformancePreviewResponse, PerformanceCursorResponse, PerformanceDetailResponse, MyPerformanceSummaryResponse 등)의 이미지 표현을 List<String> imageUrls → String imageUrl(단일 URL)로 통일. 해당 DTO들의 static factory 시그니처가 imageUrl(및 경우에 따라 performers 리스트)을 인자로 받도록 변경.
- API/프레젠테이션 변경: 컨트롤러 및 문서 컨트롤러(PerformanceCommandController, PerformanceCommandDocsController)에서 요청 파트 `images`(List) → `image`(MultipartFile)로 변경. presentation.request DTO의 toServiceRequest 메서드 시그니처 및 매핑도 단수 이미지로 변경.
- 쿼리/JPQL 정리: PerformanceJpaRepository 및 QueryDSL 레포지토리에서 select distinct / fetch join 제거(중복 처리/패치 전략 변경), findDetailById의 명시적 fetch 쿼리 제거로 이미지/퍼포머를 별도 조회하도록 변경.
- 테스트 보강: PerformanceQueryServiceTest에 PerformanceImageRepository 및 PerformerRepository mocking 추가 및 이미지/퍼포머 매핑 검증 추가.

---

## Task by CodeRabbit (요약된 작업 목록)

- Performance: images/performers 빌더 파라미터 제거, addImage/addPerformer/clearImages/clearPerformers 삭제.
- PerformanceImage: performanceId 컬럼 매핑 수정(insertable/updatable 옵션 제거 → nullable=false, unique=true), sortOrder 제거, 빌더 시그니처 변경.
- Performer: performanceId 필드(컬럼 performance_id, nullable=false) 추가, 빌더 생성자 시그니처에 performanceId 포함.
- Repository 계층 추가/변경: PerformanceImageRepository, PerformerRepository 도메인 인터페이스 + JpaRepository 인터페이스 및 Impl 클래스 추가(조회/삭제/저장 메서드 구현).
- 서비스 로직 수정: PerformanceCommandService 단일 이미지 업로드/후처리 로직 적용, 퍼포머 저장/삭제를 performanceId 기준으로 분리.
- 쿼리/응답 생성 수정: PerformanceQueryService에 getImageUrlMap 추가하여 이미지 URL을 미리 조회하고 각 DTO의 factory에 imageUrl 전달.
- DTO/프레젠테이션 수정: 모든 공연 관련 요청/응답 DTO 및 컨트롤러에서 이미지 타입을 List → 단일 MultipartFile/String으로 변경.
- JPQL/QueryDSL 수정: select distinct 및 fetch join 제거로 관련 쿼리 단순화.
- 테스트 업데이트: 이미지/퍼포머 매핑 검증 추가 및 관련 레포지토리 모킹 확장.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SWYP12-UNIBUSK/unibusk-backend/pull/235?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->