### PR TITLE
Refactor: Nginx HTTP/2 적용

### DIFF
--- a/deployment/prod/nginx/unibusk-blue.conf
+++ b/deployment/prod/nginx/unibusk-blue.conf
@@ -12,8 +12,9 @@ server {
 }
 
 server {
-    listen 443 ssl http2;
-    listen [::]:443 ssl http2;
+    listen 443 ssl;
+    listen [::]:443 ssl;
+    http2 on;
     server_name unibusk.site www.unibusk.site;
 
     client_max_body_size 500M;

--- a/deployment/prod/nginx/unibusk-blue.conf
+++ b/deployment/prod/nginx/unibusk-blue.conf
@@ -12,8 +12,8 @@ server {
 }
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
     server_name unibusk.site www.unibusk.site;
 
     client_max_body_size 500M;

--- a/deployment/prod/nginx/unibusk-green.conf
+++ b/deployment/prod/nginx/unibusk-green.conf
@@ -12,8 +12,9 @@ server {
 }
 
 server {
-    listen 443 ssl http2;
-    listen [::]:443 ssl http2;
+    listen 443 ssl;
+    listen [::]:443 ssl;
+    http2 on;
     server_name unibusk.site www.unibusk.site;
 
     client_max_body_size 500M;

--- a/deployment/prod/nginx/unibusk-green.conf
+++ b/deployment/prod/nginx/unibusk-green.conf
@@ -12,8 +12,8 @@ server {
 }
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
     server_name unibusk.site www.unibusk.site;
 
     client_max_body_size 500M;


### PR DESCRIPTION
## 관련 이슈
- #237 
## Summary
Nginx HTTP/2 적용으로 다중 요청 병렬 처리 성능 개선

## Tasks
- Nginx HTTP/2 적용 (blue, green)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

이 PR에서는 Nginx 설정에 HTTP/2 프로토콜 지원을 추가했습니다. HTTPS 서버 블록의 리스너 설정에 `http2` 옵션을 추가하여 HTTP/2 프로토콜을 활성화하였으며, 이를 통해 다중 요청의 병렬 처리 성능을 개선하고자 합니다.

## Task by CodeRabbit

- `deployment/prod/nginx/unibusk-blue.conf`의 HTTPS 리스너 설정에 `http2` 추가
  - 기존: `listen 443 ssl;` → 변경: `listen 443 ssl http2;`
  - 기존: `listen [::]:443 ssl;` → 변경: `listen [::]:443 ssl http2;`

- `deployment/prod/nginx/unibusk-green.conf`의 HTTPS 리스너 설정에 `http2` 추가
  - 기존: `listen 443 ssl;` → 변경: `listen 443 ssl http2;`
  - 기존: `listen [::]:443 ssl;` → 변경: `listen [::]:443 ssl http2;`

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SWYP12-UNIBUSK/unibusk-backend/pull/238?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->