### PR TITLE
Refactor: Nginx HTTP/2 적용 (listen http2 방식)

### DIFF
--- a/deployment/prod/nginx/unibusk-blue.conf
+++ b/deployment/prod/nginx/unibusk-blue.conf
@@ -12,9 +12,8 @@ server {
 }
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
-    http2 on;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
     server_name unibusk.site www.unibusk.site;
 
     client_max_body_size 500M;

--- a/deployment/prod/nginx/unibusk-green.conf
+++ b/deployment/prod/nginx/unibusk-green.conf
@@ -12,9 +12,8 @@ server {
 }
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
-    http2 on;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
     server_name unibusk.site www.unibusk.site;
 
     client_max_body_size 500M;


### PR DESCRIPTION
## 관련 이슈
- #239 

## Summary

**Nginx 1.24.0 버전 호환성을 위해 http2 on 방식에서 listen http2 방식으로 변경**

## Tasks

- unibusk-blue.conf http2 on → listen 443 ssl http2 방식으로 변경
- unibusk-green.conf http2 on → listen 443 ssl http2 방식으로 변경