### PR TITLE
Perf: 지도/검색 조회 N+1 문제 해결 (fetch join 적용)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ out/
 application-*.yml
 
 .DS_Store
+
+# 로컬 전용 성능 분석 문서 (GitHub 비공개)
+docs/perf/

--- a/src/main/java/team/unibusk/backend/domain/performanceLocation/infrastructure/PerformanceLocationQueryDslRepository.java
+++ b/src/main/java/team/unibusk/backend/domain/performanceLocation/infrastructure/PerformanceLocationQueryDslRepository.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 import team.unibusk.backend.domain.performanceLocation.domain.PerformanceLocation;
 import team.unibusk.backend.domain.performanceLocation.domain.QPerformanceLocation;
+import team.unibusk.backend.domain.performanceLocation.domain.QPerformanceLocationImage;
 
 import java.util.List;
 
@@ -16,25 +17,30 @@ public class PerformanceLocationQueryDslRepository {
 
     public List<PerformanceLocation> findInMapBounds(Double north, Double south, Double east, Double west) {
         QPerformanceLocation p = QPerformanceLocation.performanceLocation;
+        QPerformanceLocationImage img = QPerformanceLocationImage.performanceLocationImage;
 
         return queryFactory
                 .selectFrom(p)
+                .leftJoin(p.images, img).fetchJoin()
                 .where(p.latitude.between(south, north)
                         .and(p.longitude.between(west, east)))
+                .distinct()
                 .fetch();
     }
 
     public List<PerformanceLocation> searchByNameOrAddress(String keyword) {
         QPerformanceLocation location = QPerformanceLocation.performanceLocation;
+        QPerformanceLocationImage img = QPerformanceLocationImage.performanceLocationImage;
 
         return queryFactory
                 .selectFrom(location)
+                .leftJoin(location.images, img).fetchJoin()
                 .where(
                         location.name.containsIgnoreCase(keyword)
                                 .or(location.address.containsIgnoreCase(keyword))
                 )
+                .distinct()
                 .fetch();
     }
-
 
 }

--- a/src/main/java/team/unibusk/backend/global/config/SecurityConfig.java
+++ b/src/main/java/team/unibusk/backend/global/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package team.unibusk.backend.global.config;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -27,6 +28,7 @@ import java.util.List;
 
 import static org.springframework.security.config.http.SessionCreationPolicy.STATELESS;
 
+@Profile("!test")
 @RequiredArgsConstructor
 @Configuration
 public class SecurityConfig {

--- a/src/main/java/team/unibusk/backend/global/config/SwaggerConfig.java
+++ b/src/main/java/team/unibusk/backend/global/config/SwaggerConfig.java
@@ -10,9 +10,11 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 
 import java.util.List;
 
+@Profile("!test")
 @RequiredArgsConstructor
 @Configuration
 public class SwaggerConfig {

--- a/src/test/java/team/unibusk/backend/domain/performanceLocation/infrastructure/PerformanceLocationQueryDslRepositoryTest.java
+++ b/src/test/java/team/unibusk/backend/domain/performanceLocation/infrastructure/PerformanceLocationQueryDslRepositoryTest.java
@@ -43,7 +43,7 @@ class PerformanceLocationQueryDslRepositoryTest extends IntegrationTestSupport {
     }
 
     @Test
-    void 지도_범위_조회_시_발생하는_쿼리_수를_측정한다() {
+    void 지도_범위_조회_시_이미지_N플러스1이_발생하지_않는다() {
         SessionFactory sf = em.getEntityManagerFactory().unwrap(SessionFactory.class);
         Statistics stats = sf.getStatistics();
         stats.setStatisticsEnabled(true);
@@ -59,6 +59,9 @@ class PerformanceLocationQueryDslRepositoryTest extends IntegrationTestSupport {
         long elapsed = System.currentTimeMillis() - start;
 
         assertThat(result).hasSize(3);
+        assertThat(stats.getCollectionFetchCount())
+                .as("N+1 발생: 이미지 컬렉션 추가 SELECT가 %d회 발생했습니다.", stats.getCollectionFetchCount())
+                .isZero();
 
         System.out.println("========================================");
         System.out.println("[ findInMapBounds N+1 측정 ]");
@@ -66,13 +69,11 @@ class PerformanceLocationQueryDslRepositoryTest extends IntegrationTestSupport {
         System.out.println("▶ 응답 시간            : " + elapsed + "ms");
         System.out.println("▶ 쿼리 실행 수         : " + stats.getQueryExecutionCount());
         System.out.println("▶ 컬렉션 추가 SELECT   : " + stats.getCollectionFetchCount());
-        System.out.println("  N+1이면 추가 SELECT = " + result.size());
-        System.out.println("  fetch join이면 추가 SELECT = 0");
         System.out.println("========================================");
     }
 
     @Test
-    void 키워드_검색_시_발생하는_쿼리_수를_측정한다() {
+    void 키워드_검색_시_이미지_N플러스1이_발생하지_않는다() {
         SessionFactory sf = em.getEntityManagerFactory().unwrap(SessionFactory.class);
         Statistics stats = sf.getStatistics();
         stats.setStatisticsEnabled(true);
@@ -88,6 +89,9 @@ class PerformanceLocationQueryDslRepositoryTest extends IntegrationTestSupport {
         long elapsed = System.currentTimeMillis() - start;
 
         assertThat(result).hasSize(3);
+        assertThat(stats.getCollectionFetchCount())
+                .as("N+1 발생: 이미지 컬렉션 추가 SELECT가 %d회 발생했습니다.", stats.getCollectionFetchCount())
+                .isZero();
 
         System.out.println("========================================");
         System.out.println("[ searchByNameOrAddress N+1 측정 ]");
@@ -95,14 +99,12 @@ class PerformanceLocationQueryDslRepositoryTest extends IntegrationTestSupport {
         System.out.println("▶ 응답 시간            : " + elapsed + "ms");
         System.out.println("▶ 쿼리 실행 수         : " + stats.getQueryExecutionCount());
         System.out.println("▶ 컬렉션 추가 SELECT   : " + stats.getCollectionFetchCount());
-        System.out.println("  N+1이면 추가 SELECT = " + result.size());
-        System.out.println("  fetch join이면 추가 SELECT = 0");
         System.out.println("========================================");
     }
 
-    @ParameterizedTest(name = "지도_범위_조회_장소_{0}개_규모별_측정")
+    @ParameterizedTest(name = "지도_범위_조회_장소_{0}개_N플러스1_없음")
     @ValueSource(ints = {10, 100, 1000})
-    void 지도_범위_조회_데이터_규모별_쿼리_수를_측정한다(int count) {
+    void 지도_범위_조회_데이터_규모별_N플러스1이_발생하지_않는다(int count) {
         List<PerformanceLocation> locations = new ArrayList<>();
         for (int i = 0; i < count; i++) {
             locations.add(makeLocation(
@@ -131,6 +133,9 @@ class PerformanceLocationQueryDslRepositoryTest extends IntegrationTestSupport {
         long elapsed = System.currentTimeMillis() - start;
 
         assertThat(result).hasSize(count);
+        assertThat(stats.getCollectionFetchCount())
+                .as("N+1 발생: 이미지 컬렉션 추가 SELECT가 %d회 발생했습니다.", stats.getCollectionFetchCount())
+                .isZero();
 
         System.out.println("========================================");
         System.out.println("[ findInMapBounds - 장소 " + count + "개 규모 측정 ]");
@@ -138,14 +143,12 @@ class PerformanceLocationQueryDslRepositoryTest extends IntegrationTestSupport {
         System.out.println("▶ 응답 시간            : " + elapsed + "ms");
         System.out.println("▶ 쿼리 실행 수         : " + stats.getQueryExecutionCount());
         System.out.println("▶ 컬렉션 추가 SELECT   : " + stats.getCollectionFetchCount());
-        System.out.println("  N+1이면 추가 SELECT = " + result.size());
-        System.out.println("  fetch join이면 추가 SELECT = 0");
         System.out.println("========================================");
     }
 
-    @ParameterizedTest(name = "키워드_검색_장소_{0}개_규모별_측정")
+    @ParameterizedTest(name = "키워드_검색_장소_{0}개_N플러스1_없음")
     @ValueSource(ints = {10, 100, 1000})
-    void 키워드_검색_데이터_규모별_쿼리_수를_측정한다(int count) {
+    void 키워드_검색_데이터_규모별_N플러스1이_발생하지_않는다(int count) {
         List<PerformanceLocation> locations = new ArrayList<>();
         for (int i = 0; i < count; i++) {
             locations.add(makeLocation(
@@ -174,6 +177,9 @@ class PerformanceLocationQueryDslRepositoryTest extends IntegrationTestSupport {
         long elapsed = System.currentTimeMillis() - start;
 
         assertThat(result).hasSize(count);
+        assertThat(stats.getCollectionFetchCount())
+                .as("N+1 발생: 이미지 컬렉션 추가 SELECT가 %d회 발생했습니다.", stats.getCollectionFetchCount())
+                .isZero();
 
         System.out.println("========================================");
         System.out.println("[ searchByNameOrAddress - 장소 " + count + "개 규모 측정 ]");
@@ -181,8 +187,6 @@ class PerformanceLocationQueryDslRepositoryTest extends IntegrationTestSupport {
         System.out.println("▶ 응답 시간            : " + elapsed + "ms");
         System.out.println("▶ 쿼리 실행 수         : " + stats.getQueryExecutionCount());
         System.out.println("▶ 컬렉션 추가 SELECT   : " + stats.getCollectionFetchCount());
-        System.out.println("  N+1이면 추가 SELECT = " + result.size());
-        System.out.println("  fetch join이면 추가 SELECT = 0");
         System.out.println("========================================");
     }
 
@@ -196,7 +200,7 @@ class PerformanceLocationQueryDslRepositoryTest extends IntegrationTestSupport {
                 .longitude(lng)
                 .images(List.of(
                         PerformanceLocationImage.builder()
-                                .imageUrl("https://performanceLocations/test.jpg")
+                                .imageUrl("https://unibusk-bucket.s3.amazonaws.com/performanceLocations/test.jpg")
                                 .build()
                 ))
                 .build();

--- a/src/test/java/team/unibusk/backend/domain/performanceLocation/infrastructure/PerformanceLocationQueryDslRepositoryTest.java
+++ b/src/test/java/team/unibusk/backend/domain/performanceLocation/infrastructure/PerformanceLocationQueryDslRepositoryTest.java
@@ -1,0 +1,209 @@
+package team.unibusk.backend.domain.performanceLocation.infrastructure;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.hibernate.SessionFactory;
+import org.hibernate.stat.Statistics;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+import team.unibusk.backend.domain.performanceLocation.domain.PerformanceLocation;
+import team.unibusk.backend.domain.performanceLocation.domain.PerformanceLocationImage;
+import team.unibusk.backend.global.support.IntegrationTestSupport;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Transactional
+class PerformanceLocationQueryDslRepositoryTest extends IntegrationTestSupport {
+
+    @Autowired
+    private PerformanceLocationQueryDslRepository performanceLocationQueryDslRepository;
+
+    @PersistenceContext
+    private EntityManager em;
+
+    @BeforeEach
+    void setUp() {
+        persists(List.of(
+                makeLocation("홍대 걷고싶은거리 버스킹존1",  "서울시 마포구 어울마당로 107", 37.5546, 126.9225),
+                makeLocation("홍대 걷고싶은거리 버스킹존 2", "서울시 마포구 어울마당로 111", 37.5548, 126.9228),
+                makeLocation("홍대 걷고싶은거리 버스킹존 3", "서울시 마포구 어울마당로 127", 37.5559, 126.9240),
+                makeLocation("광나루 버스킹 장소",           "서울시 광진구 천호대로",       37.5419, 127.1155),
+                makeLocation("잠원 버스킹 장소4",            "서울시 서초구 잠원동 83-6",    37.5324, 126.9244)
+        ));
+
+        em.flush();
+        em.clear();
+    }
+
+    @Test
+    void 지도_범위_조회_시_발생하는_쿼리_수를_측정한다() {
+        SessionFactory sf = em.getEntityManagerFactory().unwrap(SessionFactory.class);
+        Statistics stats = sf.getStatistics();
+        stats.setStatisticsEnabled(true);
+        stats.clear();
+
+        long start = System.currentTimeMillis();
+
+        List<PerformanceLocation> result = performanceLocationQueryDslRepository
+                .findInMapBounds(37.560, 37.554, 126.930, 126.920);
+
+        result.forEach(l -> l.getImages().size());
+
+        long elapsed = System.currentTimeMillis() - start;
+
+        assertThat(result).hasSize(3);
+
+        System.out.println("========================================");
+        System.out.println("[ findInMapBounds N+1 측정 ]");
+        System.out.println("▶ 조회 장소 수         : " + result.size());
+        System.out.println("▶ 응답 시간            : " + elapsed + "ms");
+        System.out.println("▶ 쿼리 실행 수         : " + stats.getQueryExecutionCount());
+        System.out.println("▶ 컬렉션 추가 SELECT   : " + stats.getCollectionFetchCount());
+        System.out.println("  N+1이면 추가 SELECT = " + result.size());
+        System.out.println("  fetch join이면 추가 SELECT = 0");
+        System.out.println("========================================");
+    }
+
+    @Test
+    void 키워드_검색_시_발생하는_쿼리_수를_측정한다() {
+        SessionFactory sf = em.getEntityManagerFactory().unwrap(SessionFactory.class);
+        Statistics stats = sf.getStatistics();
+        stats.setStatisticsEnabled(true);
+        stats.clear();
+
+        long start = System.currentTimeMillis();
+
+        List<PerformanceLocation> result = performanceLocationQueryDslRepository
+                .searchByNameOrAddress("홍대");
+
+        result.forEach(l -> l.getImages().size());
+
+        long elapsed = System.currentTimeMillis() - start;
+
+        assertThat(result).hasSize(3);
+
+        System.out.println("========================================");
+        System.out.println("[ searchByNameOrAddress N+1 측정 ]");
+        System.out.println("▶ 조회 장소 수         : " + result.size());
+        System.out.println("▶ 응답 시간            : " + elapsed + "ms");
+        System.out.println("▶ 쿼리 실행 수         : " + stats.getQueryExecutionCount());
+        System.out.println("▶ 컬렉션 추가 SELECT   : " + stats.getCollectionFetchCount());
+        System.out.println("  N+1이면 추가 SELECT = " + result.size());
+        System.out.println("  fetch join이면 추가 SELECT = 0");
+        System.out.println("========================================");
+    }
+
+    @ParameterizedTest(name = "지도_범위_조회_장소_{0}개_규모별_측정")
+    @ValueSource(ints = {10, 100, 1000})
+    void 지도_범위_조회_데이터_규모별_쿼리_수를_측정한다(int count) {
+        List<PerformanceLocation> locations = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            locations.add(makeLocation(
+                    "규모테스트 장소 " + i,
+                    "서울시 테스트구 " + i,
+                    37.400 + (i * 0.0001),
+                    126.800 + (i * 0.0001)
+            ));
+        }
+        persists(locations);
+        em.flush();
+        em.clear();
+
+        SessionFactory sf = em.getEntityManagerFactory().unwrap(SessionFactory.class);
+        Statistics stats = sf.getStatistics();
+        stats.setStatisticsEnabled(true);
+        stats.clear();
+
+        long start = System.currentTimeMillis();
+
+        List<PerformanceLocation> result = performanceLocationQueryDslRepository
+                .findInMapBounds(37.502, 37.399, 126.902, 126.799);
+
+        result.forEach(l -> l.getImages().size());
+
+        long elapsed = System.currentTimeMillis() - start;
+
+        assertThat(result).hasSize(count);
+
+        System.out.println("========================================");
+        System.out.println("[ findInMapBounds - 장소 " + count + "개 규모 측정 ]");
+        System.out.println("▶ 조회 장소 수         : " + result.size());
+        System.out.println("▶ 응답 시간            : " + elapsed + "ms");
+        System.out.println("▶ 쿼리 실행 수         : " + stats.getQueryExecutionCount());
+        System.out.println("▶ 컬렉션 추가 SELECT   : " + stats.getCollectionFetchCount());
+        System.out.println("  N+1이면 추가 SELECT = " + result.size());
+        System.out.println("  fetch join이면 추가 SELECT = 0");
+        System.out.println("========================================");
+    }
+
+    @ParameterizedTest(name = "키워드_검색_장소_{0}개_규모별_측정")
+    @ValueSource(ints = {10, 100, 1000})
+    void 키워드_검색_데이터_규모별_쿼리_수를_측정한다(int count) {
+        List<PerformanceLocation> locations = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            locations.add(makeLocation(
+                    "규모테스트 장소 " + i,
+                    "서울시 테스트구 " + i,
+                    37.400 + (i * 0.0001),
+                    126.800 + (i * 0.0001)
+            ));
+        }
+        persists(locations);
+        em.flush();
+        em.clear();
+
+        SessionFactory sf = em.getEntityManagerFactory().unwrap(SessionFactory.class);
+        Statistics stats = sf.getStatistics();
+        stats.setStatisticsEnabled(true);
+        stats.clear();
+
+        long start = System.currentTimeMillis();
+
+        List<PerformanceLocation> result = performanceLocationQueryDslRepository
+                .searchByNameOrAddress("규모테스트");
+
+        result.forEach(l -> l.getImages().size());
+
+        long elapsed = System.currentTimeMillis() - start;
+
+        assertThat(result).hasSize(count);
+
+        System.out.println("========================================");
+        System.out.println("[ searchByNameOrAddress - 장소 " + count + "개 규모 측정 ]");
+        System.out.println("▶ 조회 장소 수         : " + result.size());
+        System.out.println("▶ 응답 시간            : " + elapsed + "ms");
+        System.out.println("▶ 쿼리 실행 수         : " + stats.getQueryExecutionCount());
+        System.out.println("▶ 컬렉션 추가 SELECT   : " + stats.getCollectionFetchCount());
+        System.out.println("  N+1이면 추가 SELECT = " + result.size());
+        System.out.println("  fetch join이면 추가 SELECT = 0");
+        System.out.println("========================================");
+    }
+
+    private PerformanceLocation makeLocation(String name, String address, double lat, double lng) {
+        return PerformanceLocation.builder()
+                .name(name)
+                .address(address)
+                .operatorName("운영자")
+                .operatorPhoneNumber("02-0000-0000")
+                .latitude(lat)
+                .longitude(lng)
+                .images(List.of(
+                        PerformanceLocationImage.builder()
+                                .imageUrl("https://performanceLocations/test.jpg")
+                                .build()
+                ))
+                .build();
+    }
+
+    private void persists(List<PerformanceLocation> locations) {
+        locations.forEach(em::persist);
+    }
+
+}

--- a/src/test/java/team/unibusk/backend/domain/performanceLocation/infrastructure/PerformanceLocationQueryDslRepositoryTest.java
+++ b/src/test/java/team/unibusk/backend/domain/performanceLocation/infrastructure/PerformanceLocationQueryDslRepositoryTest.java
@@ -4,6 +4,7 @@ import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import org.hibernate.SessionFactory;
 import org.hibernate.stat.Statistics;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -28,8 +29,17 @@ class PerformanceLocationQueryDslRepositoryTest extends IntegrationTestSupport {
     @PersistenceContext
     private EntityManager em;
 
+    private Statistics stats;
+    private boolean previousStatisticsEnabled;
+
     @BeforeEach
     void setUp() {
+        SessionFactory sf = em.getEntityManagerFactory().unwrap(SessionFactory.class);
+        stats = sf.getStatistics();
+
+        previousStatisticsEnabled = stats.isStatisticsEnabled();
+        stats.setStatisticsEnabled(true);
+
         persists(List.of(
                 makeLocation("홍대 걷고싶은거리 버스킹존1",  "서울시 마포구 어울마당로 107", 37.5546, 126.9225),
                 makeLocation("홍대 걷고싶은거리 버스킹존 2", "서울시 마포구 어울마당로 111", 37.5548, 126.9228),
@@ -42,11 +52,13 @@ class PerformanceLocationQueryDslRepositoryTest extends IntegrationTestSupport {
         em.clear();
     }
 
+    @AfterEach
+    void tearDown() {
+        stats.setStatisticsEnabled(previousStatisticsEnabled);
+    }
+
     @Test
     void 지도_범위_조회_시_이미지_N플러스1이_발생하지_않는다() {
-        SessionFactory sf = em.getEntityManagerFactory().unwrap(SessionFactory.class);
-        Statistics stats = sf.getStatistics();
-        stats.setStatisticsEnabled(true);
         stats.clear();
 
         long start = System.currentTimeMillis();
@@ -74,9 +86,6 @@ class PerformanceLocationQueryDslRepositoryTest extends IntegrationTestSupport {
 
     @Test
     void 키워드_검색_시_이미지_N플러스1이_발생하지_않는다() {
-        SessionFactory sf = em.getEntityManagerFactory().unwrap(SessionFactory.class);
-        Statistics stats = sf.getStatistics();
-        stats.setStatisticsEnabled(true);
         stats.clear();
 
         long start = System.currentTimeMillis();
@@ -118,9 +127,6 @@ class PerformanceLocationQueryDslRepositoryTest extends IntegrationTestSupport {
         em.flush();
         em.clear();
 
-        SessionFactory sf = em.getEntityManagerFactory().unwrap(SessionFactory.class);
-        Statistics stats = sf.getStatistics();
-        stats.setStatisticsEnabled(true);
         stats.clear();
 
         long start = System.currentTimeMillis();
@@ -162,9 +168,6 @@ class PerformanceLocationQueryDslRepositoryTest extends IntegrationTestSupport {
         em.flush();
         em.clear();
 
-        SessionFactory sf = em.getEntityManagerFactory().unwrap(SessionFactory.class);
-        Statistics stats = sf.getStatistics();
-        stats.setStatisticsEnabled(true);
         stats.clear();
 
         long start = System.currentTimeMillis();

--- a/src/test/java/team/unibusk/backend/global/config/TestSecurityConfig.java
+++ b/src/test/java/team/unibusk/backend/global/config/TestSecurityConfig.java
@@ -2,15 +2,15 @@ package team.unibusk.backend.global.config;
 
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Profile;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.web.cors.CorsUtils;
 
-@EnableWebSecurity
 @TestConfiguration
+@Profile("test")
 public class TestSecurityConfig {
 
     @Bean


### PR DESCRIPTION
## 관련 이슈
- #241

## Summary

`PerformanceLocation` 지도 조회 및 검색 조회에서 발생하던 N+1 문제를 fetch join으로 해결했습니다.

기존에는 장소 목록 조회 후 각 장소의 이미지를 개별 SELECT로 로딩하여 장소 수만큼 추가 쿼리가 발생했습니다.
`LEFT JOIN FETCH`를 적용해 단일 쿼리로 장소와 이미지를 함께 조회하도록 개선했습니다.

## Tasks

- `PerformanceLocationQueryDslRepository.findInMapBounds()` — fetch join 적용으로 N+1 제거
- `PerformanceLocationQueryDslRepository.searchByNameOrAddress()` — fetch join 적용으로 N+1 제거
- `PerformanceLocationQueryDslRepositoryTest` — Hibernate Statistics 기반 N+1 측정 통합 테스트 추가


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

PerformanceLocation 지도 범위 조회(findInMapBounds)와 키워드 검색(searchByNameOrAddress)에서 발생하던 N+1 쿼리 문제를 **LEFT JOIN FETCH**로 해결했습니다. 기존에는 위치 목록 조회 후 각 위치의 이미지를 별도 SELECT로 로드했으나, 이제는 위치와 연관된 이미지들을 단일 쿼리로 함께 조회하며, JOIN으로 인한 중복을 방지하기 위해 `distinct()`를 적용했습니다.

테스트 환경 격리를 위해 Spring Profile을 활용해 설정 클래스들을 분리했습니다:
- `SecurityConfig`와 `SwaggerConfig`에 `@Profile("!test")` 추가 — 테스트 프로파일에서는 로드되지 않음
- `TestSecurityConfig`에 `@Profile("test")` 추가 및 `@EnableWebSecurity` 제거 — 테스트 전용 설정으로 제한

N+1 문제 해결을 검증하는 **통합 테스트**를 추가했습니다. `PerformanceLocationQueryDslRepositoryTest`는 Hibernate Statistics를 사용해 쿼리 실행 수와 컬렉션 추가 SELECT 수를 측정하고, `getImages()` 접근 시 컬렉션 패치가 추가 조회를 발생시키지 않음을 확인합니다. 테스트는 다양한 엔티티 수(예: 10/100/1000)를 대상으로 반복 검증하며, 테스트용 엔티티 생성/영속화 헬퍼와 테스트 후 Hibernate Statistics 상태 복구 로직을 포함합니다.

추가적 변경:
- `QPerformanceLocationImage` import 및 변수 선언 추가
- `.gitignore`에 `.DS_Store` 및 `docs/perf/` 디렉터리 추가

## Task by CodeRabbit

- `PerformanceLocationQueryDslRepository.findInMapBounds()`에 LEFT JOIN FETCH 적용 (이미지 컬렉션 페치)
- `PerformanceLocationQueryDslRepository.searchByNameOrAddress()`에 LEFT JOIN FETCH 적용 (이미지 컬렉션 페치)
- 두 쿼리에 `distinct()` 추가로 중복 결과 제거
- `QPerformanceLocationImage` 관련 import/변수 추가
- `PerformanceLocationQueryDslRepositoryTest` 통합 테스트 추가
  - Hibernate Statistics로 쿼리/컬렉션 조회 통계 측정
  - N+1 회귀 방지 검증 (다양한 데이터 규모에 대해)
  - 엔티티 생성 및 영속화 헬퍼, 통계 상태 복구 로직 포함
- `SecurityConfig`에 `@Profile("!test")` 추가
- `SwaggerConfig`에 `@Profile("!test")` 추가
- `TestSecurityConfig`에 `@Profile("test")` 추가 및 `@EnableWebSecurity` 제거
- `.gitignore`에 `.DS_Store` 및 `docs/perf/` 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->