### PR TITLE
Refactor: logback-spring.xml local 패턴 개선 및 test 프로필 추가

### DIFF
--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -2,9 +2,21 @@
 
     <springProfile name="local">
         <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
-            <withJansi>true</withJansi>
             <encoder>
-                <pattern>%d{HH:mm:ss} %highlight(%-5level) [%cyan(%X{traceId})] [%magenta(%X{method} %X{uri})] %yellow(%logger{36}) - %msg%n</pattern>
+                <charset>UTF-8</charset>
+                <pattern>%d{HH:mm:ss} %highlight(%-5level) %yellow(%logger{36}) - %msg%n</pattern>
+            </encoder>
+        </appender>
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
+        </root>
+    </springProfile>
+
+    <springProfile name="test">
+        <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+            <encoder>
+                <charset>UTF-8</charset>
+                <pattern>%d{HH:mm:ss} %-5level %logger{36} - %msg%n</pattern>
             </encoder>
         </appender>
         <root level="INFO">


### PR DESCRIPTION
## 관련 이슈
- #245

## Summary

`logback-spring.xml` local 환경 로그 패턴을 개선하고 test 프로필을 추가했습니다.
불필요한 `withJansi` 설정 제거, UTF-8 charset 명시, MDC 제거로 스타트업 로그의 빈 괄호 문제를 해결했습니다.

## Tasks

- `withJansi` 제거 (Spring Boot 4.x 불필요) 및 UTF-8 charset 명시
- local 패턴 MDC 제거 — 빈 괄호(`[] [ ]`) 노출 문제 해결 및 가독성 개선
- `test` 프로필 추가 — 통합 테스트 실행 시 로그 출력되도록 설정
