### PR TITLE
Fix: 이미지 RequestPart 필드명을 image에서 images로 변경

### DIFF
--- a/src/main/java/team/unibusk/backend/domain/performance/presentation/command/PerformanceCommandController.java
+++ b/src/main/java/team/unibusk/backend/domain/performance/presentation/command/PerformanceCommandController.java
@@ -23,7 +23,7 @@ public class PerformanceCommandController implements PerformanceCommandDocsContr
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<PerformanceRegisterResponse> registerPerformance(
             @RequestPart("request") @Valid PerformanceRegisterRequest request,
-            @RequestPart(value = "image", required = false) MultipartFile image,
+            @RequestPart(value = "images", required = false) MultipartFile image,
             @MemberId Long memberId
     ) {
         PerformanceRegisterResponse response =
@@ -36,7 +36,7 @@ public class PerformanceCommandController implements PerformanceCommandDocsContr
     public ResponseEntity<PerformanceDetailResponse> updatePerformance(
             @PathVariable Long performanceId,
             @RequestPart("request") @Valid PerformanceUpdateRequest request,
-            @RequestPart(value = "image", required = false) MultipartFile image,
+            @RequestPart(value = "images", required = false) MultipartFile image,
             @MemberId Long memberId
     ) {
         PerformanceDetailResponse response = performanceCommandService.updatePerformance(request.toServiceRequest(performanceId, memberId, image));

--- a/src/main/java/team/unibusk/backend/domain/performance/presentation/command/PerformanceCommandDocsController.java
+++ b/src/main/java/team/unibusk/backend/domain/performance/presentation/command/PerformanceCommandDocsController.java
@@ -44,7 +44,7 @@ public interface PerformanceCommandDocsController {
     ResponseEntity<PerformanceRegisterResponse> registerPerformance(
             @RequestPart("request") @Valid PerformanceRegisterRequest request,
             @Parameter(description = "공연 관련 이미지")
-            @RequestPart(value = "image", required = false) MultipartFile image,
+            @RequestPart(value = "images", required = false) MultipartFile image,
             @MemberId Long memberId
     );
 
@@ -64,7 +64,7 @@ public interface PerformanceCommandDocsController {
     ResponseEntity<PerformanceDetailResponse> updatePerformance(
             @PathVariable Long performanceId,
             @RequestPart("request") @Valid PerformanceUpdateRequest request,
-            @RequestPart(value = "image", required = false) MultipartFile image,
+            @RequestPart(value = "images", required = false) MultipartFile image,
             @MemberId Long memberId
     );
 


### PR DESCRIPTION
## 관련 이슈
- #247 

## Summary

**이미지 업로드 API의 @RequestPart 이름을 image → images로 변경** 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

이 PR은 이미지 업로드 API의 요청 파라미터 이름을 변경하는 수정사항입니다. `PerformanceCommandController`의 이미지 파일 업로드 기능에서 multipart form-data의 필드명을 변경했습니다.

## Task by CodeRabbit

- `registerPerformance` 엔드포인트에서 이미지 업로드 시 `@RequestPart` 필드명을 `"image"`에서 `"images"`로 변경
- `updatePerformance` 엔드포인트에서 이미지 업로드 시 `@RequestPart` 필드명을 `"image"`에서 `"images"`로 변경
  - 두 엔드포인트 모두 `required = false` 유지하여 선택적 이미지 업로드 지원 (issue `#247` 관련)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->