### PR TITLE
Fix: 프론트 요청 규격에 맞춰 이미지 Requestpart 이름 변경

### DIFF
--- a/src/main/java/team/unibusk/backend/domain/performance/presentation/command/PerformanceCommandController.java
+++ b/src/main/java/team/unibusk/backend/domain/performance/presentation/command/PerformanceCommandController.java
@@ -23,7 +23,7 @@ public class PerformanceCommandController implements PerformanceCommandDocsContr
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<PerformanceRegisterResponse> registerPerformance(
             @RequestPart("request") @Valid PerformanceRegisterRequest request,
-            @RequestPart(value = "image", required = false) MultipartFile image,
+            @RequestPart(value = "images", required = false) MultipartFile image,
             @MemberId Long memberId
     ) {
         PerformanceRegisterResponse response =
@@ -36,7 +36,7 @@ public class PerformanceCommandController implements PerformanceCommandDocsContr
     public ResponseEntity<PerformanceDetailResponse> updatePerformance(
             @PathVariable Long performanceId,
             @RequestPart("request") @Valid PerformanceUpdateRequest request,
-            @RequestPart(value = "image", required = false) MultipartFile image,
+            @RequestPart(value = "images", required = false) MultipartFile image,
             @MemberId Long memberId
     ) {
         PerformanceDetailResponse response = performanceCommandService.updatePerformance(request.toServiceRequest(performanceId, memberId, image));

--- a/src/main/java/team/unibusk/backend/domain/performance/presentation/command/PerformanceCommandDocsController.java
+++ b/src/main/java/team/unibusk/backend/domain/performance/presentation/command/PerformanceCommandDocsController.java
@@ -44,7 +44,7 @@ public interface PerformanceCommandDocsController {
     ResponseEntity<PerformanceRegisterResponse> registerPerformance(
             @RequestPart("request") @Valid PerformanceRegisterRequest request,
             @Parameter(description = "공연 관련 이미지")
-            @RequestPart(value = "image", required = false) MultipartFile image,
+            @RequestPart(value = "images", required = false) MultipartFile image,
             @MemberId Long memberId
     );
 
@@ -64,7 +64,7 @@ public interface PerformanceCommandDocsController {
     ResponseEntity<PerformanceDetailResponse> updatePerformance(
             @PathVariable Long performanceId,
             @RequestPart("request") @Valid PerformanceUpdateRequest request,
-            @RequestPart(value = "image", required = false) MultipartFile image,
+            @RequestPart(value = "images", required = false) MultipartFile image,
             @MemberId Long memberId
     );
 


### PR DESCRIPTION
## 관련 이슈
- #247

## Summary

**Requestpart 이름 image -> images로 변경**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

이 PR은 프론트엔드 요청 명세와의 호환성을 맞추기 위해 성능 공연 API의 멀티파트 파일 업로드 RequestPart 필드명을 "image"에서 "images"로 변경했습니다. 애플리케이션 로직 코드와 Swagger API 문서에서 일관되게 변경사항을 반영했습니다.

## Task by CodeRabbit

- `PerformanceCommandController`의 `registerPerformance` 메서드에서 `@RequestPart(value = "image", required = false)`를 `@RequestPart(value = "images", required = false)`로 변경
- `PerformanceCommandController`의 `updatePerformance` 메서드에서 `@RequestPart(value = "image", required = false)`를 `@RequestPart(value = "images", required = false)`로 변경
- `PerformanceCommandDocsController`의 `registerPerformance` 메서드에서 `@RequestPart(value = "image", required = false)`를 `@RequestPart(value = "images", required = false)`로 변경 (Swagger API 문서 업데이트)
- `PerformanceCommandDocsController`의 `updatePerformance` 메서드에서 `@RequestPart(value = "image", required = false)`를 `@RequestPart(value = "images", required = false)`로 변경 (Swagger API 문서 업데이트)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->